### PR TITLE
Don't Default Google Analytics Transaction To US

### DIFF
--- a/templates/modules/analytics/google-analytics-ecommerce-tracking-code.hypr
+++ b/templates/modules/analytics/google-analytics-ecommerce-tracking-code.hypr
@@ -7,7 +7,7 @@
     '{{ model.shippingTotal }}',
     '{{ model.fulfillmentInfo.fulfillmentContact.address.cityOrTown }}',
     '{{ model.fulfillmentInfo.fulfillmentContact.address.stateOrProvince }}',
-    'USA'
+    '{{ model.fulfillmentInfo.fulfillmentContact.address.countryCode|escapejs }}'
     ]);
 
     {% for item in model.items %}


### PR DESCRIPTION
Sends the 2 character country code.  This does not need to be 3 characters.

[This page](https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApiEcommerce#_gat.GA_Tracker_._addTrans) states:
`Note: The optional geographic information that can be included in a transaction object is not used to populate geographic data in Google Analytics reports; however, it can be used in a view filter.`