### PR TITLE
Add promoCodeAlreadyUsed label

### DIFF
--- a/labels/en-US.json
+++ b/labels/en-US.json
@@ -151,6 +151,7 @@
   "useShippingAddress"   : "Use my shipping address",
   "optIn"                : "Yes! I want to receive news and special offers from {0}!",
   "promoCodeError"     : "Sorry, '{0}' does not appear to be a valid coupon code.",
+  "promoCodeAlreadyUsed" : "The promo code '{0}' has already been applied.",
   "reviewOrder"          : "Review & Place Order",
   "reviewOrderText": "Please review all of the information on this page and, if necessary, make changes before placing your order.",
   "recalculatePayments": "Your order total has changed. Please re-enter your payment information to recalculate payment.",


### PR DESCRIPTION
The label 'promoCodeAlreadyUsed' is referenced [here in models-checkout.js](https://github.com/Mozu/core-theme/blob/master/scripts/modules/models-checkout.js#L934) but not defined; please add it to the labels file.