### PR TITLE
Update about-us.hypr

### DIFF
--- a/templates/pages/about-us.hypr
+++ b/templates/pages/about-us.hypr
@@ -7,7 +7,7 @@
 
  {% block body-content %}
 
-	 <div>{{model.properties.blurb|safe}}<div>
+	 <div>{{model.properties.blurb|safe}}</div>
 
 	{% dropzone "body" scope="page" %}
 {% endblock body-content %}


### PR DESCRIPTION
Missing `/` in closing div, resulting in browser auto closing tag scopes prematurely.