### PR TITLE
Store affiliate tracking strings in cart

### DIFF
--- a/scripts/modules/api.js
+++ b/scripts/modules/api.js
@@ -8,6 +8,9 @@ define(['sdk', 'jquery', 'hyprlive'], function (Mozu, $, Hypr) {
     var apiConfig = require.mozuData('apicontext');
     Mozu.setServiceUrls(apiConfig.urls);
     var api = Mozu.Store(apiConfig.headers).api();
+
+    api.setAffiliateTrackingParameters(Hypr.getThemeSetting('extendedPropertyParameters'));
+
     if (Hypr.getThemeSetting('useDebugScripts') || require.mozuData('pagecontext').isDebugMode) {
         api.on('error', function (badPromise, xhr, requestConf) {
             var e = "Error communicating with Mozu web services";

--- a/theme-ui.json
+++ b/theme-ui.json
@@ -17,7 +17,26 @@
                 }
             ]
         },
-        {            "title": "Product Lists",
+        {
+            "xtype": "panel",
+            "title": "Extended Properties",
+            "collapsed":false,
+            "items": [
+                {
+                    "xtype": "mz-input-checkbox",
+                    "name": "extendedPropertiesEnabled",
+                    "fieldLabel": "Enable Extended Properties (Tracking Strings)"
+                },
+                {
+                    "xtype": "mz-input-textarea",
+                    "name": "extendedPropertyParameters",
+                    "fieldLabel": "Query Parameters (comma seperated)"
+                }
+            ]
+        },
+        {
+            "xtype": "panel",
+            "title": "Product Lists",
             "collapsed": false,
             "items": [
                 {

--- a/theme.json
+++ b/theme.json
@@ -353,6 +353,8 @@
         }
     ],
     "settings": {
+        "extendedPropertiesEnabled": false,
+        "extendedPropertyParameters": "",
         "bannerImage": "/resources/images/banner.jpg",
         "bannerImageEnabled": false,
         "bannerImageRepeat": "repeat-x",


### PR DESCRIPTION
### Feature: Storing Campaign Information in Extended Properties

We added a new Storefront SDK feature that tracks conversions by storing a campaign ID, provided from a URL at the beginning of the browser session, in a Cart Extended Property once a shopper adds an item to the cart.
#### Additions
- We added a new method to the Storefront SDK: `.setAffiliateTrackingParameters`
- We modified the Core Theme:
  - We added a theme settings to `theme.json` called `campaignIds`.
  - We added a UI control to `theme-ui.json` so that merchants could update the `campaignIds` theme setting.
  - We modified the `scripts/modules/api.js` file to use the new SDK feature.
#### Integration Options

**The preferred upgrade path is always to update your theme to extend Core7.**

If doing so results in unrelated or unpredictable regressions, then instead you can inspect the changes we made to the Core Theme and manually integrate them
#### Upgrade Process
- Extend Core7 or merge the files as described.
- Recompile your theme using the build tools.
- Perform regression tests.
- Test the functionality by:
  - Editing your Theme Settings to add a campaign ID url parameter "campaignId" or something similar.
  - Appending a URL "campaignId=1234"
  - Add an item to the cart.
  - Check the cart in admin to see if the campaign was associated.
