### PR TITLE
 Hide empty categories from storefront display

### DIFF
--- a/templates/Widgets/misc/category-navigation.hypr
+++ b/templates/Widgets/misc/category-navigation.hypr
@@ -1,15 +1,19 @@
+{% with navigation|find(model.config.mainCategory) as navNode %}
 <div class="mz-categorylist" >
-  {% with  navigation|find:Model.config.mainCategory as navNode %}
   <div class="mz-categorylist-title-{{Model.config.template}}"><a href="{{navNode.url}}">{{navNode.name}}</a></div>
   {% for item in navNode.items %}
   {% if forloop.counter0 < Model.config.numberToDisplay %}
-			<div class="mz-categorylist-list-label{{Model.config.template}}"><a href="{{item.url}}">{{ item.name }}</a></div>
-				  <ul class="mz-categorylist-list-{{Model.config.template}} {% block list-classes %}{% endblock list-classes %}">
-				  {% for subitem in item.items %}
-					<li class="mz-categorylist-item-{{Model.config.template}}"><a href="{{subitem.url}}">{{ subitem.name }}</a></li>
-				  {% endfor %}
-				  </ul>
-			{% endif %}
-	   {% endfor %}
-{% endwith %}
+  {% if not item.isEmpty or not model.config.hideEmptyChildNodes %}
+  <div class="mz-categorylist-list-label{{Model.config.template}}"><a href="{{item.url}}">{{ item.name }}</a></div>
+    <ul class="mz-categorylist-list-{{Model.config.template}} {% block list-classes %}{% endblock list-classes %}">
+    {% for subitem in item.items %}
+    {% if not subitem.isEmpty or not model.config.hideEmptyChildNodes %}
+      <li class="mz-categorylist-item-{{Model.config.template}}"><a href="{{subitem.url}}">{{ subitem.name }}</a></li>
+    {% endif %}
+	{% endfor %}
+	</ul>
+  {% endif %}
+  {% endif %}
+  {% endfor %}
 </div>
+{% endwith %}

--- a/templates/modules/page-header/search-box.hypr
+++ b/templates/modules/page-header/search-box.hypr
@@ -7,9 +7,12 @@
             data-mz-contextify='[value="categoryId:{{ pageContext.categoryId }}"]'
             data-mz-contextify-attr='selected'
             data-mz-contextify-val='selected'>
+        <option value="">{{ labels.all }}</option>
         {% partial_cache %}
-        {% for cat in navigation.rootCategories %}
-        <option value="categoryId:{{cat.originalId}}">{{cat.Name}}</option>
+        {% for node in navigation.tree %}
+        {% if node.nodeType == "category" and not node.isEmpty %}
+        <option value="categoryId:{{node.originalId}}">{{node.name}}</option>
+        {% endif %}
 		{% endfor %}
         {% endpartial_cache %}
 	</select>

--- a/templates/modules/site-nav.hypr
+++ b/templates/modules/site-nav.hypr
@@ -3,75 +3,72 @@
         data-mz-contextify='.mz-sitenav-link[href="{{ navigation.currentNode.url }}"]'
         data-mz-contextify-attr='class'
         data-mz-contextify-val='is-current'>
-      {% partial_cache %}
-      {% for link in navigation.tree %}
-        {% if not link.isHidden and forloop.counter0 < themeSettings.maxTopLevelNavItems %}
-        
+        {% partial_cache %}
+        {% for link in navigation.tree %}
+        {% if not link.isHidden and not link.isEmpty and forloop.counter0 < themeSettings.maxTopLevelNavItems %}
         <li class="mz-sitenav-item">
           <div class="mz-sitenav-item-inner">
             <a class="mz-sitenav-link" href="{{link.url}}">{{link.name|truncatechars(themeSettings.maxTopLevelNavLabelLength)|safe}}</a>
             {% if link.items %}
             <ul class="mz-sitenav-sub">
               {% for sublink in link.items %}
-                {% if not sublink.isHidden %}
-                <li data-mz-role="sitemenu-item" class="mz-sitenav-item">
-                  <a class="mz-sitenav-link" href="{{sublink.url}}">{{ sublink.name|safe }}</a>
-                  {%comment%}
-                  <!-- uncoment out  this block to get 3rd laver of nav -->
-                  {% if sublink.items %}
-                  <ul class="mz-sitenav-sub-sub">
-                    {% for subsublink in sublink.items %}
-                      {% if not subsublink.isHidden %}
-                        <li class="mz-sitenav-item">
+                    {% if not sublink.isHidden and not sublink.isEmpty %}
+              <li data-mz-role="sitemenu-item" class="mz-sitenav-item">
+                <a class="mz-sitenav-link" href="{{sublink.url}}">{{ sublink.name|safe }}</a>
+                {%comment%}
+                <!-- uncoment out  this block to get 3rd laver of nav -->
+                {% if sublink.items %}
+                <ul class="mz-sitenav-sub-sub">
+                  {% for subsublink in sublink.items %}
+                            {% if not subsublink.isHidden and not subsublink.isEmpty %}
+                  <li class="mz-sitenav-item">
                           <a class="mz-sitenav-link" href="{{subsublink.url}}">{{ subsublink.name|safe }}</a>
-                        </li>
-                      {% endif %}
-                    {% endfor %}
-                  </ul>
-                  {% endif %}
-                  {%endcomment%}
-                </li>
+                  </li>
+                            {% endif %}
+                  {% endfor %}
+                </ul>
                 {% endif %}
+                {%endcomment%}
+              </li>
+                    {% endif %}
               {% endfor %}
             </ul>
             {% endif %}
           </div>
-        </li>
-        {% endif %}
-      {% endfor %}
-      {% if navigation.tree.length > themeSettings.maxTopLevelNavItems %}
+            </li>
+            {% endif %}
+        {% endfor %}
+        {% if navigation.tree.length > themeSettings.maxTopLevelNavItems %}
         <li class="mz-sitenav-item mz-sitenav-item-more">
             <div class="mz-sitenav-item-inner">
                 <a class="mz-sitenav-link" href="javascript:;">{{ labels.navMore }}</a>
                 <ul class="mz-sitenav-sub">
-                  {% for sublink in navigation.tree %}
-                    {% if not sublink.isHidden and sublink.index >= themeSettings.maxTopLevelNavItems %}
-                      <li data-mz-role="sitemenu-item" class="mz-sitenav-item">
+                    {% for sublink in navigation.tree %}
+                    {% if sublink.index >= themeSettings.maxTopLevelNavItems and not sublink.isHidden and not sublink.isEmpty %}
+                        <li data-mz-role="sitemenu-item" class="mz-sitenav-item">
                                 <a class="mz-sitenav-link" href="{{sublink.url}}">{{sublink.name|safe}}</a>
                               {% if sublink.items %}
-                              {%comment%}
-                              <!-- uncoment out  this block to get 3rd laver of nav -->
+                        {% comment %}
+                        <!-- uncomment out  this block to get 3rd laver of nav -->
                                        <ul class="mz-sitenav-sub-sub">
-                                         {% for subsublink in sublink.items %}
-                                           {% if not subsublink.isHidden %}
-                                             <li class="mz-sitenav-item">
-                                               <a class="mz-sitenav-link" href="{{subsublink.url}}">{{subsublink.name|safe}}</a>
-                                             </li>
-                                           {% endif %}
-                                         {% endfor %}
-                                         </ul>
-
-                              {%endcomment%}
+                                            {% for subsublink in sublink.items %}
+                            {% if not subsublink.isHidden and not subsublink.isEmpty %}
+                                                <li class="mz-sitenav-item">
+                                                    <a class="mz-sitenav-link" href="{{subsublink.url}}">{{subsublink.name|safe}}</a>
+                                                </li>
+                            {% endif %}
+                                            {% endfor %}
+                                        </ul>
+                        {% endcomment %}
                               {% endif %}
                             </li>
-                    {% endif %}
-                  {% endfor %}
+                        {% endif %}
+                    {% endfor %}
                 </ul>
             </div>
         </li>
-      {% endif %}
-      {% endpartial_cache %}
-      {% require_script "modules/contextify" %}
+        {% endif %}
+        {% endpartial_cache %}
+        {% require_script "modules/contextify" %}
     </ul>
 </nav>
-    

--- a/theme.json
+++ b/theme.json
@@ -762,6 +762,12 @@
                     "fieldLabel": "Number to display",
                     "name": "numberToDisplay",
                     "xtype": "mz-input-number"
+                },
+                {
+                    "anchor": "100%",
+                    "fieldLabel": "Hide Empty Child Nodes",
+                    "name": "hideEmptyChildNodes",
+                    "xtype": "mz-input-checkbox"
                 }
             ],
             "icon": "/resources/admin/widgets/22_category_navigation.png",


### PR DESCRIPTION
### Feature: Hiding Empty Categories from Storefront Display

We added a new property to navigation nodes, the objects that are on the `navigation.tree` in Hypr templates. The property, `isEmpty`, is `true` if the category (and all of its subcategories) contain zero products. This allows the theme developer to design a navigation display that automatically hides empty categories from view. We implemented an example of this in the standard site navigation in the Core theme, and in two other places where lists of categories appear: the search box category selector, and the Navigation Subsection widget.
#### Additions
- We added a new method `isEmpty` property to NavigationNodes
- We modified the Core Theme:
  - We added `isEmpty` tests to `templates/modules/site-nav.hypr`.
  - We added `isEmpty` tests to `templates/modules/page-header/search-box.hypr`
  - We added `isEmpty` tests to `templates/widgets/misc/category.navigation.hypr`
  - We added another control to the widget control panel for the Navigation Subsection, to control this behavior, in `theme.json`
#### Integration Options

**The preferred upgrade path is always to update your theme to extend Core7.**

If doing so results in unrelated or unpredictable regressions, then instead you can inspect the changes we made to the Core Theme and manually integrate them.
#### Upgrade Process
- Extend Core7 or merge the files as described.
- Recompile your theme using the build tools.
- Perform regression tests.
- Test the functionality by:
  - Placing a Navigation Subsection widget and selecting a category with a subcategory known to be empty. Check the "Hide Empty" box and see if it hides the subcategory correctly.
  - Editing your implementation of global site navigation to check against the `isEmpty` property.

Note that you should perform these tests in **staging mode**, since the navigation tree takes several minutes to update in live mode.
