### PR TITLE
Add duty fee row to order detail templates

### DIFF
--- a/labels/de-DE.json
+++ b/labels/de-DE.json
@@ -24,6 +24,7 @@
     "total"   : "Gesamt",
     "subtotal"   : "Zwischensumme",
     "tax"   : "Steuer",
+    "taxDuty": "Zölle und Steuern",
     "shippingHandling"   : "Versandkosten",
     "additionalHandling"   : "Zusätzliche Handhabung",
     "digitalCreditTotal"   : "Weniger   : Geschenkkarten",

--- a/labels/en-US.json
+++ b/labels/en-US.json
@@ -23,6 +23,7 @@
   "total"                : "Total",
   "subtotal"             : "Subtotal",
   "tax"                  : "Tax",
+  "taxDuty"              : "Duties and Taxes",
   "shippingHandling"     : "Shipping & Handling",
   "additionalHandling"   : "Additional Handling",
   "digitalCreditTotal"   : "Less: Gift Cards",

--- a/templates/back-office/order-details.hypr
+++ b/templates/back-office/order-details.hypr
@@ -76,6 +76,17 @@
                         <td>({{ model.storeCredit|currency }})</td>
                     </tr>
                 {% endif %}
+                {% if model.dutyTotal %}
+                <tr>
+                    <td colspan="5">Duties and Taxes</td>
+                    <td>{{ model.dutyTotal|add(model.taxTotal)|currency }}</td>
+                </tr>
+                {% else %}
+                <tr>
+                    <td colspan="5">Tax</td>
+                    <td>{{ model.taxTotal|currency }}</td>
+                </tr>
+                {% endif %}
                 <tr>                    <td colspan="5">Tax</td>
                     <td>{{ model.taxTotal|currency }}</td>
                 </tr><tr>

--- a/templates/modules/common/email-order-summary.hypr.live
+++ b/templates/modules/common/email-order-summary.hypr.live
@@ -8,24 +8,24 @@
             </tr>
         </thead>
         {% for item in model.items %}
-            <tbody class="mz-ordersummary-lineitems">
-              <tr class="mz-ordersummary-line mz-ordersummary-line-item {% if item.discountTotal > 0 %}is-discounted{% endif %}">
-                    <td class="mz-ordersummary-item-product">
-                      {{ item.product.name }}
-                      {% if item.product.productUsage == 'Bundle' %}
-                      <dl class="mz-propertylist">
-                        {% for bundledProduct in item.product.bundledProducts %}
-                        <dt>{{ bundledProduct.productCode }}</dt>&nbsp;
-                        <dd>{{ bundledProduct.name }} ({{ bundledProduct.quantity }})</dd>
-                        {% endfor %}
-                      </dl>
-                      {% endif %}
-                    </td>
-                    <td>{{ item.quantity }}</td>
-                    <td align="right"> {% include "modules/common/email-item-price" %}</td>
-                    <td align="right"> {% include "modules/common/email-item-total" %}</td>
-                </tr>
-            </tbody>
+        <tbody class="mz-ordersummary-lineitems">
+          <tr class="mz-ordersummary-line mz-ordersummary-line-item {% if item.discountTotal > 0 %}is-discounted{% endif %}">
+                <td class="mz-ordersummary-item-product">
+                  {{ item.product.name }}
+                  {% if item.product.productUsage == 'Bundle' %}
+                  <dl class="mz-propertylist">
+                    {% for bundledProduct in item.product.bundledProducts %}
+                    <dt>{{ bundledProduct.productCode }}</dt>&nbsp;
+                    <dd>{{ bundledProduct.name }} ({{ bundledProduct.quantity }})</dd>
+                    {% endfor %}
+                  </dl>
+                  {% endif %}
+                </td>
+                <td>{{ item.quantity }}</td>
+                <td align="right"> {% include "modules/common/email-item-price" %}</td>
+                <td align="right"> {% include "modules/common/email-item-total" %}</td>
+            </tr>
+        </tbody>
         {% endfor %}
       
         <tbody>
@@ -44,13 +44,23 @@
                 <span class="mz-ordersummary-totalname">{{ labels.subtotal }}:</span>
                 <span class="mz-ordersummary-totalvalue">{{ model.discountedSubTotal|currency }}</span>
               </td>
+            </tr>        
+            {% if model.dutyTotal %}
+            <tr class="mz-ordersummary-tax">
+                <td align="right" colspan="4">
+                    <span class="mz-ordersummary-totalname">{{ labels.taxDuty }}:</span>
+                    <span class="mz-ordersummary-totalvalue">{{ model.dutyTotal|add(model.taxTotal)|currency }}</span>
+                </td>
             </tr>
-            {% else %}            <tr class="mz-ordersummary-tax">
+            {% else %}
+            {% if model.taxTotal %}
+            <tr class="mz-ordersummary-tax">
                 <td align="right" colspan="4">
                     <span class="mz-ordersummary-totalname">{{ labels.tax }}:</span>
                     <span class="mz-ordersummary-totalvalue">{{ model.taxTotal|currency }}</span>
                 </td>
             </tr>
+            {% endif %}
             {% endif %}
             <tr class="mz-ordersummary-shippingtotal">
               <td align="right" colspan="4">

--- a/templates/modules/common/order-summary.hypr.live
+++ b/templates/modules/common/order-summary.hypr.live
@@ -48,6 +48,14 @@
           </tr>
           {% endif %}
           {% endfor %}
+          {% if model.dutyTotal %}
+          <tr class="mz-ordersummary-tax">
+              <td colspan="4">
+                  <span class="mz-ordersummary-totalname">{{ labels.taxDuty }}:</span>
+                  <span class="mz-ordersummary-totalvalue">{{ model.dutyTotal|add(model.taxTotal)|currency }}</span>
+              </td>
+          </tr>
+          {% else %}
           {% if model.taxTotal %}
           <tr class="mz-ordersummary-tax">
                 <td colspan="4">
@@ -55,6 +63,7 @@
                     <span class="mz-ordersummary-totalvalue">{{ model.taxTotal|currency }}</span>
                 </td>
             </tr>
+            {% endif %}
             {% endif %}
             <tr class="mz-ordersummary-shippingtotal">
               <td colspan="4">


### PR DESCRIPTION
### Feature: Duty Fees

We added a new feature that allows a customer to add duty fees to their order. The Storefront update allows a customer to see duty fees that are applied to their order.
#### Additions
- We added a new property `dutyTotal` to Orders
- We modified the Core Theme:
  - We added a new label variable to `/labels/en-US.json` and the example `/labels/de-DE.json` called `taxDuty`; the default value, for English, is "Duties and Taxes". This needs to be added for the following fields to display properly.
  - We added a new variable to the order model called `dutyTotal`; it is only populated when duty fee has been added to an order.
  - We modified the `templates/back-office/order-details.hypr`, `templates/back-office/email-order-summary.hypr.live`, and `templates/back-office/order-summary.hypr.live` files to check the new model varable. If it is populated, the label for tax is replaced by the label for `taxDuty` defined above and the applied duty fee is added to the tax to create the new field.
#### Integration Options

**The preferred upgrade path is always to update your theme to extend Core7.**

If doing so results in unrelated or unpredictable regressions, then instead you can inspect the changes we made to the Core Theme and manually integrate them

Upgrade Process
- Extend Core7 or merge the files as described.
- Recompile your theme using the build tools.
- Perform regression tests.
- Test the functionality by:
  - Creating an order that will trigger a duty fee calculation and continuing to view the cart.
  - The appropriate label described above should display along with the calculated duty fee and tax, if applicable.
