### PR TITLE
Add JCB credit card option to credit card form

### DIFF
--- a/labels/en-US.json
+++ b/labels/en-US.json
@@ -61,6 +61,7 @@
   "ccMastercard"     : "MasterCard",
   "ccAmericanExpress"    : "American Express",
   "ccDiscover"       : "Discover",
+  "ccJcb"       : "JCB",
 
   "payPal"               : "Paypal Express",
   "password"             : "Password",

--- a/templates/modules/common/credit-card-form.hypr.live
+++ b/templates/modules/common/credit-card-form.hypr.live
@@ -18,6 +18,9 @@
         {% if siteContext.checkoutSettings.supportedCards.discover %}
         <option value="DISCOVER" {% if model.paymentOrCardType == "DISCOVER" %}selected="selected"{% endif %}>{{ labels.ccDiscover }}</option>
         {% endif %}
+        {% if siteContext.checkoutSettings.supportedCards.jcb %}
+        <option value="JCB" {% if model.paymentOrCardType == "JCB" %}selected="selected"{% endif %}>{{ labels.ccJcb }}</option>
+        {% endif %}
     </select>
             <span class="mz-validationmessage" data-mz-validationmessage-for="{{ cardcontext }}paymentOrCardType"></span>
         </div>


### PR DESCRIPTION
### Feature: JCB Credit Card Option

We added a new feature that allows a customer to use the JCB credit card when checking out. The Core Theme update includes a new label string for JCB, and a new option in the credit card form template.
#### Additions
- We added support for the JBC credit card to our payment services
- We modified the Core Theme:
  - We added a new label variable to `/labels/en-US.json` called `ccJcb`; the default value, for English, is "JCB".
  - We modified the `templates/modules/common/credit-card-form.hypr.live` file to add an option for JCB in the card dropdown.
#### Integration Options

**The preferred upgrade path is always to update your theme to extend Core7.**

If doing so results in unrelated or unpredictable regressions, then instead you can inspect the changes we made to the Core Theme and manually integrate them

Upgrade Process
- Extend Core7 or merge the files as described.
- Recompile your theme using the build tools.
- Perform regression tests.
- Test the functionality by:
  - Enabling the JCB credit card in your Payment settings.
  - Adding a product to a cart, continuing to checkout, and proceeding to the payment step.
  - The JCB card should display as an option.
