### PR TITLE
Dynamic set of "reason" options for RMAs

### DIFF
--- a/labels/de-DE.json
+++ b/labels/de-DE.json
@@ -324,7 +324,7 @@
     "differentExpectations"   : "Anders als das, was erwartet wurde,",
     "defective"   : "Defekt - nicht richtig funktioniert",
     "noLongerWanted"   : "Nicht mehr benötigte / wanted",
-    "tooLate"   : "Kam zu spät",
+    "late"   : "Kam zu spät",
     "wrongCountryForType"   : "Bitte wählen Sie ein Land für diesen Kontakt Typ unterstützt",
     "digitalCodeAlreadyUsed"   : "Dieser Code wurde bereits verwendet.",
     "digitalCreditExceedsBalance": "Der Betrag, gelten übersteigt die verbleibende Gesamt.",

--- a/labels/en-US.json
+++ b/labels/en-US.json
@@ -346,7 +346,7 @@
   "differentExpectations": "Different from what was expected",
   "defective"            : "Defective - does not work properly",
   "noLongerWanted"       : "No longer needed/wanted",
-  "tooLate"              : "Arrived too late",
+  "late"              : "Arrived too late",
   "wrongCountryForType"  : "Please select a country supported for this contact type",
   "digitalCodeAlreadyUsed": "This code has already been used.",
   "digitalCreditExceedsBalance": "The amount to apply exceeds the total remaining.",

--- a/templates/modules/common/item-return-form.hypr.live
+++ b/templates/modules/common/item-return-form.hypr.live
@@ -6,9 +6,9 @@
       </div>
       <div class="mz-l-formfieldgroup-cell">
         <label>
-          <input type="radio" name="returnType" value="Refund" data-mz-value="rma.returnType" checked="checked"> {{ labels.refund }} </label>
+          <input type="radio" name="returnType" value="Refund" data-mz-value="rma.returnType" checked="checked"/> {{ labels.refund }} </label>
         <label>
-          <input type="radio" name="returnType" value="Replace" data-mz-value="rma.returnType" > {{ labels.replace }} </label>
+          <input type="radio" name="returnType" value="Replace" data-mz-value="rma.returnType" /> {{ labels.replace }} </label>
       </div>
     </div>
     <div class="mz-l-formfieldgroup-row">
@@ -18,13 +18,9 @@
       <div class="mz-l-formfieldgroup-cell">
         <select data-mz-value="rma.reason" class="mz-returnform-reason">
           <option value="">{{ labels.pleaseSelect }}</option>
-          <option value="Damaged">{{ labels.damaged }}</option>
-          <option value="Defective">{{ labels.defective }}</option>
-          <option value="DifferentExpectations">{{ labels.differentExpectations }}</option>
-          <option value="Late">{{ labels.tooLate }}</option>
-          <option value="MissingParts">{{ labels.missingParts }}</option>
-          <option value="NoLongerWanted">{{ labels.noLongerWanted }}</option>
-          <option value="Other">{{ labels.other }}</option>
+          {% for reason in pageContext.reasonCollection.items %}
+          <option value="{{reason}}">{{ labels|prop(reason) }}</option>
+          {% endfor %}
         </select>
         <span class="mz-validationmessage" data-mz-validationmessage-for="rma.reason"></span>
       </div>


### PR DESCRIPTION
### Feature: Dynamic set of "reason" options for RMAs

We added a new feature to the RMA workflow that allows custom return reasons. To support custom return reasons, we modified Hypr templates to use a dynamic collection of available return reasons instead of static ones.
#### Additions
- We modified the template `templates/moculdes/common/item-return-form` so that it used a collection of dynamic return reasons to populate the Reason dropdown.
#### Integration Options

**The preferred upgrade path is always to update your theme to extend Core8.**

If doing so results in unrelated or unpredictable regressions, then instead you can inspect the changes we made to the Core Theme and manually integrate them.
#### Upgrade Process
- Extend Core8 or merge the files as described.
- Recompile your theme using the build tools.
- Perform regression tests.
- Test the functionality by:
  - Use the new Admin functionality to add or modify return reasons.
  - Check to see that your newly added reason is automatically available in the RMA interface in the My Account page.
