### PR TITLE
Discount Coupon Messaging Improvement

### DIFF
--- a/labels/de-DE.json
+++ b/labels/de-DE.json
@@ -52,6 +52,7 @@
     "status"   : "Status",
     "comments"   : "Kommentare",
     "couponCode"   : "Gutschein-Code",
+    "couponDisclaimer" : "Notiz: \"{0}\" könnte bei der Kasse angewendet werden.",
     "apply"   : "anwenden",
     "nameOnCheck"   : "Name On prüfen",
     "routingNumber"   : "Routing Number",

--- a/labels/en-US.json
+++ b/labels/en-US.json
@@ -54,6 +54,7 @@
   "status"               : "Status",
   "comments"             : "Comments",
   "couponCode"           : "Coupon Code",
+  "couponDisclaimer"     : "Note: \"{0}\" may be reflected in checkout.",
   "apply"                : "Apply",
   "nameOnCheck"          : "Name On Check",
   "routingNumber"        : "Routing Number",

--- a/scripts/modules/models-cart.js
+++ b/scripts/modules/models-cart.js
@@ -90,14 +90,23 @@
                 var shippingDiscounts = _.flatten(_.pluck(_.pluck(me.get('items').models, 'attributes'), 'shippingDiscounts'));
 
                 var allDiscounts = me.get('orderDiscounts').concat(productDiscounts).concat(shippingDiscounts);
+                var allCodes = me.get('couponCodes') || [];
                 var lowerCode = code.toLowerCase();
-                if (!allDiscounts || !_.find(allDiscounts, function (d) {
-                    return d.couponCode.toLowerCase() === lowerCode;
-                })) {
+
+                var couponExists = _.find(allCodes, function(couponCode) {
+                    return couponCode.toLowerCase() === lowerCode;
+                });
+                if (!couponExists) {
                     me.trigger('error', {
                         message: Hypr.getLabel('promoCodeError', code)
                     });
                 }
+
+                var couponIsNotApplied = (!allDiscounts || !_.find(allDiscounts, function(d) {
+                    return d.couponCode.toLowerCase() === lowerCode;
+                }));
+                me.set('tentativeCoupon', couponExists && couponIsNotApplied ? code : undefined);
+
                 me.isLoading(false);
             });
         }

--- a/templates/modules/common/coupon-code-field.hypr.live
+++ b/templates/modules/common/coupon-code-field.hypr.live
@@ -5,3 +5,8 @@
             <input type="text" id="coupon-code" name="coupon-code" value="{{ model.couponCode }}" data-mz-value="couponCode">
             <button type="button" id="cart-coupon-code" class="mz-button" data-mz-action="addCoupon" {% if not model.couponCode %} disabled="disabled" {% endif %}>{{ labels.apply }}</button>
         </div>
+        {% if model.tentativeCoupon %}
+        <div>
+            <span>{{labels.couponDisclaimer|string_format(model.tentativeCoupon)|safe}}</span>
+        </div>
+        {% endif %}


### PR DESCRIPTION
**#69819:** On the cart page, show a note acknowledging "possible" coupon codes rather than throwing an error.
