### PR TITLE
Add support for volume pricing in price lists.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ node_modules/
 .yo-rc.json
 mozu.config.json
 
+# WebStorm project files
+.idea/
+

--- a/labels/de-DE.json
+++ b/labels/de-DE.json
@@ -341,6 +341,7 @@
     "chooseShippingMethod"   : "Bitte wählen Sie eine Versandmethode.",
     "didNotAgreeToTerms"   : "Sie müssen zu den Bedingungen einverstanden",
     "enterProductQuantity"   : "Bitte geben Sie eine Produktmenge über 0",
+    "enterMinProductQuantity" : "Bitte geben Sie eine minimale Produktmenge von {0}",
     "enterReturnReason"   : "Bitte wählen Sie ein Rückgabegrund.",
     "enterReturnQuantity"   : "Bitte geben Sie eine Menge über 1 zurückzukehren.",
     "enterOtherComments"   : "Bitte geben Sie einen Kommentar, die die Gründe für diese Rückkehr.",
@@ -400,5 +401,12 @@
 
     "dealOfTheDay"     : "Angebot des Tages",
     "exclusivePricelist": "Die folgenden Produkte sind nicht zum Kauf zur Verfügung und wurden entfernt.",
-    "newPriceList": "Sie sind nun berechtigt, für spezielle Preise."
+    "newPriceList": "Sie sind nun berechtigt, für spezielle Preise.",
+
+    "volumePriceQuantity": "Menge",
+    "volumePriceUnitPrice": "Einzelpreis",
+    "volumePriceSavings": "Ersparnisse",
+    "volumePriceMinMaxQty": "{0} - {1}",
+    "volumePriceMinOnlyQty": "{0}+",
+    "mapPrice": "in den Warenkorb Endpreis zu sehen"
 }

--- a/labels/en-US.json
+++ b/labels/en-US.json
@@ -370,6 +370,7 @@
   "chooseShippingMethod"                  : "Please select a shipping method.",
   "didNotAgreeToTerms"                    : "You must agree to the terms and conditions",
   "enterProductQuantity"                  : "Please enter a product quantity above 0",
+  "enterMinProductQuantity"               : "Minimum required quantity for purchase is {0}",
   "enterReturnReason"                     : "Please select a return reason.",
   "enterReturnQuantity"                   : "Please enter a quantity above 1 to return.",
   "enterOtherComments"                    : "Please enter a comment explaining the reason for this return.",
@@ -437,5 +438,12 @@
   "addAddress"                            : "Add new address",
   "editAddress"                           : "Edit saved address",
   "exclusivePricelist"                    : "The following items are not available for purchase and have been removed.",
-  "newPriceList"                          : "You are now eligible for special pricing."
+  "newPriceList"                          : "You are now eligible for special pricing.",
+
+  "volumePriceQuantity"                   : "Quantity",
+  "volumePriceUnitPrice"                  : "Unit Price",
+  "volumePriceSavings"                    : "Savings",
+  "volumePriceMinMaxQty"                  : "{0} - {1}",
+  "volumePriceMinOnlyQty"                 : "{0}+",
+  "mapPrice"                              : "add to cart to see final price"
 }

--- a/scripts/modules/backbone-mozu-model.js
+++ b/scripts/modules/backbone-mozu-model.js
@@ -185,7 +185,7 @@
              * @example
              * // sets the value of Customer.EditingContact.FirstName
              * customerModel.set('editingContact.firstName');
-             * @param {string} propName The name, or dot-separated path, of the property to return.
+             * @param {string} key The name, or dot-separated path, of the property to return.
              * @returns {Object} Returns the value of the named attribute, and `undefined` if it was never set.
              */
             set: function(key, val, options) {
@@ -193,8 +193,11 @@
                 if (!key && key !== 0) return this;
 
                 containsPrice = new RegExp('price', 'i');
-                // remove any properties from the current configurable model 
+                
+                // Remove any properties from the current model 
                 // where there are properties no longer present in the latest api model.
+                // This is to fix an issue when sale price is only on certain configurations or volume price bands, 
+                // so that the sale price does not persist.
                 syncRemovedKeys = function (currentModel, attrKey) {
                     _.each(_.difference(_.keys(currentModel[attrKey].toJSON()), _.keys(attrs[attrKey])), function (keyName) {
                         changes.push(keyName);
@@ -259,7 +262,7 @@
                         current[attr] = val;
                     }
 
-                    if (current.productUsage === 'Configurable' && current[attr] instanceof Backbone.Model) {
+                    if (current[attr] instanceof Backbone.Model && containsPrice.test(attr)) {
                         syncRemovedKeys(current, attr);
                     }
                 }

--- a/scripts/modules/login-links.js
+++ b/scripts/modules/login-links.js
@@ -116,7 +116,7 @@ define(['shim!vendor/bootstrap/js/popover[shim!vendor/bootstrap/js/tooltip[modul
             }
             else {
                this.$el.on('click', _.bind(this.doFormSubmit, this));
-            }
+            }    
         },
         doFormSubmit: function(e){
             e.preventDefault();
@@ -285,7 +285,7 @@ define(['shim!vendor/bootstrap/js/popover[shim!vendor/bootstrap/js/tooltip[modul
                     },
                     password: this.$parent.find('[data-mz-signup-password]').val()
                 };
-            if (this.validate(payload)) {
+            if (this.validate(payload)) {   
                 //var user = api.createSync('user', payload);
                 this.setLoading(true);
                 return api.action('customer', 'createStorefront', payload).then(function () {
@@ -297,7 +297,7 @@ define(['shim!vendor/bootstrap/js/popover[shim!vendor/bootstrap/js/tooltip[modul
                     }
                 }, self.displayApiMessage);
             }
-        }
+        } 
     });
 
     $(document).ready(function() {
@@ -328,7 +328,7 @@ define(['shim!vendor/bootstrap/js/popover[shim!vendor/bootstrap/js/tooltip[modul
                         location.href = require.mozuData('pagecontext').secureHost + '/' + returnURL;
                     }
             });
-
+           
         });
         $('[data-mz-action="launchforgotpassword"]').each(function() {
             var popover = new LoginPopover();
@@ -366,7 +366,7 @@ define(['shim!vendor/bootstrap/js/popover[shim!vendor/bootstrap/js/tooltip[modul
 
             //if were in edit mode, we override the /logout GET, to preserve the correct referrer/page location | #64822
             if (require.mozuData('pagecontext').isEditMode) {
-
+ 
                  el.on('click', function(e) {
                     e.preventDefault();
                     $.ajax({
@@ -376,7 +376,7 @@ define(['shim!vendor/bootstrap/js/popover[shim!vendor/bootstrap/js/tooltip[modul
                     });
                 });
             }
-
+            
         });
     });
 

--- a/scripts/modules/models-cart.js
+++ b/scripts/modules/models-cart.js
@@ -34,7 +34,16 @@
             return price.baseAmount != price.discountedAmount;
         },
         saveQuantity: function() {
-            if (this.hasChanged("quantity")) this.apiUpdateQuantity(this.get("quantity"));
+            var self = this;
+            var oldQuantity = this.previous("quantity");
+            if (this.hasChanged("quantity")) {
+                this.apiUpdateQuantity(this.get("quantity"))
+                    .then(null, function() {
+                        // Quantity update failed, e.g. due to limited quantity or min. quantity not met. Roll back.
+                        self.set("quantity", oldQuantity);
+                        self.trigger("quantityupdatefailed", self, oldQuantity);
+                    });
+            }
         }
     }),
 

--- a/scripts/modules/theme-utility-bar.js
+++ b/scripts/modules/theme-utility-bar.js
@@ -19,6 +19,9 @@ define(['jquery', 'shim!modules/jquery-simple-datetimepicker[jquery=jquery]>jque
             };
         },
         ButtonHandler = function(selector) {
+            if (!selector) {
+                return;
+            }
             this.handler = $(selector);
             this.urlBar = $('#mz-url-copy');
         },
@@ -103,12 +106,12 @@ define(['jquery', 'shim!modules/jquery-simple-datetimepicker[jquery=jquery]>jque
         }).bind(this));
         
         $(document).on('click', (function(eventData){
-
-            if (eventData.target.className.indexOf('pricelist') !== -1) {
+            
+            if (!this.changedValue || eventData.target.className.indexOf('pricelist') !== -1) {
                 return;
             }
             if (!this.picker.isShow()) {
-                if (this.dateHasChanged.call(this)) location.search = this.getQueryString(this.sanitizeDate());   
+                if (this.dateHasChanged.call(this)) location.search = this.getQueryString(this.sanitizeDate());
             }
 
         }).bind(this));
@@ -195,8 +198,6 @@ define(['jquery', 'shim!modules/jquery-simple-datetimepicker[jquery=jquery]>jque
         this.handler.on('change', (function(){
             this.changedValue = true;
         }).bind(this));
-
-        //this.handler.val(this.getQueryStringValue());
     };
 
     PriceListPicker.prototype.getQueryStringValue = function() {

--- a/scripts/pages/cart.js
+++ b/scripts/pages/cart.js
@@ -16,6 +16,7 @@ define(['modules/backbone-mozu', 'underscore', 'modules/jquery-mozu', 'modules/m
                 }
             });
 
+            this.listenTo(this.model.get('items'), 'quantityupdatefailed', this.onQuantityUpdateFailed, this);
 
             var visaCheckoutSettings = HyprLiveContext.locals.siteContext.checkoutSettings.visaCheckout;
             var pageContext = require.mozuData('pagecontext');
@@ -40,6 +41,15 @@ define(['modules/backbone-mozu', 'underscore', 'modules/jquery-mozu', 'modules/m
                 item.saveQuantity();
             }
         },400),
+        onQuantityUpdateFailed: function(model, oldQuantity) {
+            var field = this.$('[data-mz-cart-item=' + model.get('id') + ']');
+            if (field) {
+                field.val(oldQuantity);
+            }
+            else {
+                this.render();
+            }
+        },
         removeItem: function(e) {
             if(require.mozuData('pagecontext').isEditMode) {
                 // 65954

--- a/scripts/pages/location.js
+++ b/scripts/pages/location.js
@@ -57,11 +57,10 @@ require(['modules/jquery-mozu', 'hyprlive', 'modules/backbone-mozu', 'modules/mo
                 });
             },
             addToCartForPickup: function (e) {
-                var self = this,
-                    $target = $(e.currentTarget),
+                var $target = $(e.currentTarget),
                     loc = $target.data('mzLocation');
                 $target.parent().addClass('is-loading');
-                this.product.addToCartForPickup(loc);
+                this.product.addToCartForPickup(loc, this.product.get('quantity'));
             },
             setProduct: function (product) {
                 var me = this;
@@ -72,6 +71,15 @@ require(['modules/jquery-mozu', 'hyprlive', 'modules/backbone-mozu', 'modules/mo
                     });
                     window.location.href = "/cart";
                 });
+                this.listenTo(me.product, 'error', function () {
+                    this.$('.is-loading').removeClass('is-loading');
+                    this.render();
+                });
+            },
+            getRenderContext: function () {
+                var c = Backbone.MozuView.prototype.getRenderContext.apply(this, arguments);
+                c.model.messages = (this.product.messages) ? this.product.messages.toJSON() : [];
+                return c;
             }
         });
 

--- a/scripts/pages/product.js
+++ b/scripts/pages/product.js
@@ -2,10 +2,11 @@
 
     var ProductView = Backbone.MozuView.extend({
         templateName: 'modules/product/product-detail',
-        autoUpdate: ['quantity'],
         additionalEvents: {
             "change [data-mz-product-option]": "onOptionChange",
-            "blur [data-mz-product-option]": "onOptionChange"
+            "blur [data-mz-product-option]": "onOptionChange",
+            "change [data-mz-value='quantity']": "onQuantityChange",
+            "keyup input[data-mz-value='quantity']": "onQuantityChange"
         },
         render: function () {
             var me = this;
@@ -17,6 +18,13 @@
         onOptionChange: function (e) {
             return this.configure($(e.currentTarget));
         },
+        onQuantityChange: _.debounce(function (e) {
+            var $qField = $(e.currentTarget),
+              newQuantity = parseInt($qField.val(), 10);
+            if (!isNaN(newQuantity)) {
+                this.model.updateQuantity(newQuantity);
+            }
+        },500),
         configure: function ($optionEl) {
             var newValue = $optionEl.val(),
                 oldValue,
@@ -95,21 +103,20 @@
             $('#add-to-wishlist').prop('disabled', 'disabled').text(Hypr.getLabel('addedToWishlist'));
         });
 
+        var productImagesView = new ProductImageViews.ProductPageImagesView({
+            el: $('[data-mz-productimages]'),
+            model: product
+        });
+
         var productView = new ProductView({
             el: $('#product-detail'),
             model: product,
             messagesEl: $('[data-mz-message-bar]')
         });
 
-        var productImagesView = new ProductImageViews.ProductPageImagesView({
-            el: $('[data-mz-productimages]'),
-            model: product
-        });
-
         window.productView = productView;
 
         productView.render();
-
 
     });
 

--- a/stylesheets/base/variables.less
+++ b/stylesheets/base/variables.less
@@ -20,6 +20,7 @@
 @unavailableText:       #ae1231;
 
 @bodyBackgroundColor:   {{ themeSettings.bodyBackgroundColor }};
+@highlightColor:        #ffffe0;
 
 @errorBorder:           darken(spin(@errorBackground, -10), 3%);
 @successBorder:         darken(spin(@successBackground, -10), 3%);

--- a/stylesheets/modules/product/volume-pricing.less
+++ b/stylesheets/modules/product/volume-pricing.less
@@ -1,0 +1,38 @@
+﻿.mz-price-container {
+    float: left;
+}
+.mz-volume-price-container {
+    float: left;
+    padding-left: @gutter;
+    padding-bottom: @gutter;
+}
+.mz-volume-pricing {
+    font-size: @fontSize;
+
+    .mz-volume-price {
+        padding-left: 2px;
+        padding-right: 2px;
+    }
+    .mz-volume-price-lower {
+        &::after {
+            content: "\2014";
+        }
+    }
+    th {
+        text-align: center;
+        padding: @gutter/2 @gutter;
+        color: #eee;
+        background-color: #666;
+        border-bottom: 1px solid #fff;
+    }
+    tr.mz-volume-pricing-active-band {
+        background-color: @highlightColor;
+    }
+    td {
+        text-align: center;
+        &.mz-volume-pricing-cell-price {
+            text-align: right;
+            padding-right: 10px;
+        }
+    }
+}

--- a/stylesheets/storefront.less
+++ b/stylesheets/storefront.less
@@ -69,6 +69,7 @@
 @import "/stylesheets/modules/product/product-images.less";
 @import "/stylesheets/modules/product/product-detail.less";
 @import "/stylesheets/modules/product/product-options.less";
+@import "/stylesheets/modules/product/volume-pricing.less";
 // Cart
 @import "/stylesheets/modules/cart/cart-table.less";
 // Checkout

--- a/templates/modules/common/message-bar.hypr.live
+++ b/templates/modules/common/message-bar.hypr.live
@@ -1,38 +1,26 @@
 ﻿<div class="mz-messagebar" data-mz-message-bar>
     {% if model.length > 0 %}
-        {% with model|first as firstItem %}
-        
-        {% if firstItem.messageType and firstItem.messageType == "exclusivePricelist" %}
-        <ul class="is-showing mz-infos">
-            {% for msg in model %}
-                <li class="mz-message-item" >{{ labels|prop(msg.messageType) }}</li>
-                <ul>
-                    {% for itemsRemoved in msg.productsRemoved %}
-                    <li class="mz-message-item">{{itemsRemoved.name}} ({% if itemsRemoved.variationProductCode %}{{itemsRemoved.variationProductCode}}{%else%}{{itemsRemoved.productCode}}{%endif%})</li>
-                    {% endfor %}
+        {% for msg in model %}
+            {% if msg.messageType and msg.messageType == "exclusivePricelist" %}
+                <ul class="is-showing mz-infos">
+                    <li class="mz-message-item" >{{ labels|prop(msg.messageType) }}</li>
+                    <ul>
+                        {% for itemsRemoved in msg.productsRemoved %}
+                        <li class="mz-message-item">{{itemsRemoved.name}} ({% if itemsRemoved.variationProductCode %}{{itemsRemoved.variationProductCode}}{%else%}{{itemsRemoved.productCode}}{%endif%})</li>
+                        {% endfor %}
+                    </ul>
                 </ul>
-            {% endfor %}
-        </ul>
-        {% else %}
-
-        {% if firstItem.messageType and firstItem.messageType == "newPricelist" %}
-        <ul class="is-showing mz-success">
-            {% for msg in model %}
-                <li class="mz-message-item" >{{ labels|prop(msg.messageType) }}</li>
-            {% endfor %}
-        </ul>
-        {% else %}
-
-        <ul class="is-showing mz-errors">
-            {% for msg in model %}
-                <li class="mz-message-item" >{{ msg.message }}</li>
-            {% endfor %}
-        </ul>
-        {% endif %}
-
-        {% endif %}
-
-        {% endwith %}
-
+            {% else %}
+                {% if msg.messageType and msg.messageType == "newPricelist" %}
+                    <ul class="is-showing mz-success">
+                        <li class="mz-message-item" >{{ labels|prop(msg.messageType) }}</li>
+                    </ul>
+                {% else %}
+                    <ul class="is-showing mz-errors">
+                        <li class="mz-message-item" >{{ msg.message }}</li>
+                    </ul>
+                {% endif %}
+            {% endif %}
+        {% endfor %}
     {% endif %}
 </div>

--- a/templates/modules/common/price.hypr.live
+++ b/templates/modules/common/price.hypr.live
@@ -6,23 +6,26 @@
      {% if model.discount.discount.name %}
      <span class="mz-price-discountname">{{model.discount.discount.name}} &ndash;</span>
      {% endif %}
-	
-     {{model.salePrice|currency}}
-	  {% if model.priceType == "MAP" %}
-		<div>add to cart to see final price</div>
+
+     {% if model.priceType != "MAP" %}
+         {{model.salePrice|currency}}
+     {% else %}
+         <div>{{ labels.mapPrice }}</div>
      {% endif %}
  </span>
  {% else %}
  <span itemprop="price" class="mz-price">
-	
-     {{model.price|currency}}
-	 {% if model.priceType == "MAP" %}
-		<div>add to cart to see final price</div>
+
+     {% if model.priceType != "MAP" %}
+         {{model.price|currency}}
+     {% else %}
+         <span class="mz-price is-crossedout">
+         {{model.price|currency}}
+         </span>
+         <div>{{ labels.mapPrice }}</div>
      {% endif %}
  </span>
  {% endif %}
  {% if themeSettings.showMSRP and model.msrp %}
  <span class="mz-price-msrp">{{ labels.msrp}}: <span class="mz-price">{{ model.msrp|currency }}</span></span>
  {% endif %}
-
-

--- a/templates/modules/common/volume-price.hypr.live
+++ b/templates/modules/common/volume-price.hypr.live
@@ -1,0 +1,24 @@
+﻿{% if model.priceType != "MAP" %}
+   {% if model.onSale or model.salePrice %}
+     <span class="mz-volume-price is-crossedout">
+       {{model.price|currency}}
+     </span>
+     <span itemprop="price" class="mz-volume-price is-saleprice">
+       {% if model.discount.discount.name %}
+         <span class="mz-price-discountname">{{model.discount.discount.name}} &ndash;</span>
+       {% endif %}
+       {{model.salePrice|currency}}
+     </span>
+   {% else %}
+     <span itemprop="price" class="mz-volume-price">
+       {{model.price|currency}}
+     </span>
+   {% endif %}
+{% else %}
+   <span class="mz-volume-price is-crossedout">
+     {{model.price|currency}}
+   </span>
+   <span>{{ labels.mapPrice }}</span>
+{% endif %}
+
+

--- a/templates/modules/location/location-search.hypr.live
+++ b/templates/modules/location/location-search.hypr.live
@@ -5,6 +5,7 @@
     <p class="mz-locationsearch-positionerror is-warning">{{ model.positionError }}</p>
     {% endif %}
     <div class="mz-l-paginatedlist-list">
+      {% include "modules/common/message-bar" with model=model.messages %}
       {% include "modules/location/location-list-for-product" with model=model.items %}
     </div>
   {% else %}

--- a/templates/modules/product/product-detail.hypr.live
+++ b/templates/modules/product/product-detail.hypr.live
@@ -11,12 +11,12 @@
   {% include "modules/product/product-options" %}
 </div>
 {% endif %}
-    
+
 <div itemprop="offers" itemscope itemtype="http://schema.org/Offer" class="mz-productdetail-price mz-l-stack-section">
   <h4 class="mz-l-stack-sectiontitle">{{ labels.price }}</h4>
 {% include "modules/product/price-stack" %}
 </div>
-
+<div class="mz-price-container">
 <dl class="mz-productcodes mz-propertylist mz-pagetitle-note mz-l-stack-section">
 	<dt class="mz-productcodes-productcode-label">{{ labels.productCode }}</dt>
 	<dd class="mz-productcodes-productcode" itemprop="sku">{{ model.variationProductCode|default(model.productCode) }}</dd>
@@ -33,29 +33,29 @@
 <section class="mz-l-stack-section mz-productdetail-conversion">
 <div class="mz-productdetail-conversion-controls">
   <span class="mz-qty-label">{{ labels.qty }}</span>
-  <input class="mz-productdetail-qty" type="number" value="1" min="1" {% if not model.purchasableState.isPurchasable %} disabled="disabled" {% endif %} data-mz-value="quantity" />
+  <input class="mz-productdetail-qty" type="number" {% if model.quantity %} value="{{ model.quantity }}" {% else %} value="1" {% endif %} min="1" {% if not model.isPurchasable %} disabled="disabled" {% endif %} data-mz-value="quantity" />
   <span class="mz-validationmessage" data-mz-validationmessage-for="quantity"></span>
 </div>
   <div class="mz-productdetail-conversion-buttons">
-  <button id="add-to-cart" class="mz-productdetail-addtocart mz-button mz-button-large {% if not model.purchasableState.isPurchasable %}is-disabled{% endif %}" {% if not model.purchasableState.isPurchasable %} disabled="disabled" {% endif %} data-mz-action="addToCart" >
+  <button id="add-to-cart" class="mz-productdetail-addtocart mz-button mz-button-large {% if not model.isPurchasable %}is-disabled{% endif %}" {% if not model.isPurchasable %} disabled="disabled" {% endif %} data-mz-action="addToCart" >
       {{ labels.addToCart }}
   </button>
 
   {% if siteContext.generalSettings.isWishlistCreationEnabled and not user.isAnonymous %}
-  <button id="add-to-wishlist" {% if model.notDoneConfiguring or not model.purchasableState.isPurchasable %} disabled="disabled" {% else %} {% if model.inventoryInfo.outOfStockBehavior == 'HideProduct' and not model.inventoryInfo.onlineStockAvailable %} disabled="disabled" {% endif %} {% endif %} class="mz-productdetail-addtowishlist mz-button {% if not model.purchasableState.isPurchasable %}is-disabled{% endif %}" data-mz-action="addToWishlist">
+  <button id="add-to-wishlist" {% if model.notDoneConfiguring or not model.isPurchasable %} disabled="disabled" {% else %} {% if model.inventoryInfo.outOfStockBehavior == 'HideProduct' and not model.inventoryInfo.onlineStockAvailable %} disabled="disabled" {% endif %} {% endif %} class="mz-productdetail-addtowishlist mz-button {% if not model.isPurchasable %}is-disabled{% endif %}" data-mz-action="addToWishlist">
       {{ labels.addToWishlist }}
   </button>
   {% endif %}
 
   {% if siteContext.supportsInStorePickup %}
   <form class="mz-instorepickup" method="POST" data-mz-localstoresform action="/location/product">
-    <button type="submit" {% if model.notDoneConfiguring or not model.purchasableState.isPurchasable or not model.supportsInStorePickup %} disabled="disabled" {% endif %} class="mz-button mz-instorepickuplink-button {% if model.notDoneConfiguring or not model.purchasableState.isPurchasable or not model.supportsInStorePickup %}is-disabled{% endif %}" data-mz-action="checkLocalStores">{{ labels.checkLocalStores }}</button>
+    <button type="submit" {% if model.notDoneConfiguring or not model.isPurchasable or not model.supportsInStorePickup %} disabled="disabled" {% endif %} class="mz-button mz-instorepickuplink-button {% if model.notDoneConfiguring or not model.isPurchasable or not model.supportsInStorePickup %}is-disabled{% endif %}" data-mz-action="checkLocalStores">{{ labels.checkLocalStores }}</button>
     <input type="hidden" data-mz-localstoresform-input name="item" value="{% json_attribute model %}" />
   </form>
   {% endif %}
   </div>
 
-  {% if not model.purchasableState.isPurchasable %}
+  {% if not model.isPurchasable %}
   <p class="mz-productdetail-notpurchasable">
     {{ labels.notPurchasable }}:
     {% for message in model.purchasableState.messages %}
@@ -64,6 +64,13 @@
   </p>
   {% endif %}
 </section>
+</div>
+
+{% if model.hasVolumePricing %}
+<div class="mz-volume-price-container">
+  {% include "modules/product/volume-pricing" %}
+</div>
+{% endif %}
 
 <div class="mz-productdetail-fulldesc mz-l-stack-section">
   <h4 class="mz-l-stack-sectiontitle">{{ labels.fullDesc }}</h4>

--- a/templates/modules/product/product-listing.hypr.live
+++ b/templates/modules/product/product-listing.hypr.live
@@ -21,7 +21,20 @@
         <div class="mz-productlisting-productcode">{{model.productCode}}</div>
         {% endif %}
         {% endblock product-code %}
-        {% include "modules/product/price-stack" %}
+
+        {% if model.volumePriceRange %}
+        <div class="mz-volume-pricing">
+            <span itemprop="minPrice" class="mz-volume-price-lower">
+                {% include "modules/common/volume-price" with model=model.volumePriceRange.lower %}
+            </span>
+            <span itemprop="maxPrice" class="mz-volume-price-upper">
+                {% include "modules/common/volume-price" with model=model.volumePriceRange.upper %}
+            </span>
+        </div>
+        {% else %}
+            {% include "modules/product/price-stack" %}
+        {% endif %}
+
         {% block product-extrainfo %}
         {% if dealOfTheDay %}
           {% if dealOfTheDay.savings %}

--- a/templates/modules/product/volume-price-stack.hypr.live
+++ b/templates/modules/product/volume-price-stack.hypr.live
@@ -1,0 +1,10 @@
+﻿{% if model.priceRange %}
+    <span itemprop="minPrice" class="mz-volume-price-lower">
+        {% include "modules/common/volume-price" with model=model.priceRange.lower %}
+    </span>
+    <span itemprop="maxPrice" class="mz-volume-price-upper">
+      {% include "modules/common/volume-price" with model=model.priceRange.upper %}
+    </span>
+{% else %}
+    {% include "modules/common/volume-price" with model=model.price %}
+{% endif %}

--- a/templates/modules/product/volume-pricing.hypr.live
+++ b/templates/modules/product/volume-pricing.hypr.live
@@ -1,0 +1,26 @@
+﻿<div class="mz-volume-pricing mz-l-column">
+<table class="mz-table">
+  <thead>
+    <tr>
+      <th class="mz-volume-pricing-header-quantity">{{ labels.volumePriceQuantity }}</th>
+      <th class="mz-volume-pricing-header-price">{{ labels.volumePriceUnitPrice }}</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for priceBand in model.volumePriceBands %}
+    <tr class="mz-volume-pricing-row{% if priceBand.isCurrent %} mz-volume-pricing-active-band{% endif %}">
+      <td class="mz-volume-pricing-cell-quantity">
+      {% if priceBand.maxQty %}
+        {{ labels.volumePriceMinMaxQty|string_format(priceBand.minQty,priceBand.maxQty) }}
+      {% else %}
+        {{ labels.volumePriceMinOnlyQty|string_format(priceBand.minQty) }}
+      {% endif %}
+      </td>
+      <td class="mz-volume-pricing-cell-price">
+        {% include "modules/product/volume-price-stack" with model=priceBand %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+</div>

--- a/theme-ui.json
+++ b/theme-ui.json
@@ -48,6 +48,11 @@
                     "xtype": "mz-input-checkbox",
                     "name": "listProductShortDesc",
                     "fieldLabel": "Show product short description in product lists"
+                },
+                {
+                    "xtype": "mz-input-checkbox",
+                    "name": "listVolumePricing",
+                    "fieldLabel": "Show volume pricing bands in product lists"
                 }
             ]
         },

--- a/theme.json
+++ b/theme.json
@@ -400,6 +400,7 @@
         "itemListingThumbSize": 80,
         "listProductCode": true,
         "listProductShortDesc": true,
+        "listVolumePricing": false,
         "listProductThumbSize": 160,
         "maxProductImageThumbnailSize": 50,
         "maxProductSummaryWords": 40,


### PR DESCRIPTION
# Volume Pricing
#### This merge request introduces the Volume Pricing feature to the Mozu Core Theme.

Discussed below are the files that have been changed/updated, and the reasoning behind those changes. The easiest way to integrate these changes is to perform a merge request. However, if you have already customized a lot of your theme files, this method may result in too many conflicts. If that's the case, then you can make the changes manually while using this documentation to understand exactly what code needs to be changed to support Volume Pricing.
### How to Make the Changes

First, incorporate the new Hypr templates. Then merge the updated JavaScript, Hypr and JSON files (labels and theme settings).  Once these files have been merged, the Volume Pricing feature should work.  Including the new stylesheet is important but not required for the feature to work.
## Files Changed:
### JavaScript

These are the main files updated by this merge request.  These files enable updates to the quantity field to call the Mozu API to retrieve the new volume price as necessary.
1. `scripts/modules/models-product.js`
   - Added two helper functions accessible from Hypr
     - `hasVolumePricing`
     - `isPurchasable`
   - Added functions for supporting Volume Pricing
     - `updateQuantity`
     - `showBelowQuantityWarning`
     - `handleMixedVolumePricingTransitions`
       - _Handles edge case when the variants of a configurable products do not have consistent pricing bands._
2. `scripts/modules/backbone-mozu-model.js`
   - Updating quantity for a volume priced product will now make an API call, so had to broaden when to sync with the API from configurable products only to models containing a price field.
3. `scripts/pages/product.js`
   - Hooked up change and keyup events on the quantity field to the `onQuantityChange` function.
   - Moved `productImagesView` after `productView` due to sequencing issue.
4. `scripts/modules/models-cart.js`
   - Revert cart item quantity if it causes an error to keep the cart and UI in sync.
5. `scripts/pages/cart.js`
   - Added function `onQuantityUpdateFailed`

There was a fix to the staging preview screen to address an issue where in some cases a mouse click refreshed the page.
- `scripts/modules/theme-utility-bar.js`
### HYPR
#### New Volume Pricing Hypr Files:

These files represent the new Volume Pricing section on the product details page.
1. `templates/modules/product/volume-pricing.hypr.live`
   - Table display of volume price bands.
2. `templates/modules/product/volume-price-stack.hypr.live`
   - Shows either the volume price or the price range for a configurable product that has not resolved to a product variant.  This is equivalent to the existing `templates/modules/product/price-stack.hypr.live`.
3. `templates/modules/common/volume-price.hypr.live`
   - Table cell level display of resolved volume price.  This is equivalent to the existing `templates/modules/common/price.hypr.live`.
#### Updated Hypr Files:
1. `templates/modules/product/product-detail.hypr.live`
   - Added volume pricing section with wrapping div, `mz-price-container`, over both standard and volume pricing sections.
   - Changed all calls from `model.purchasableState.isPurchasable` to `model.isPurchasable` to allow for helper function to intercept and include volume pricing logic.
2. `templates/modules/product/product-listing.hypr.live`
   - Added section to display volume price range.  The API will only return volume pricing if the new setting in `theme.json` is enabled.
3. `templates/modules/common/price.hypr.live`
   - Changed MAP price to use strike-through formatting.  This is not required by Volume Pricing.
   - Moved MAP text message to resource files.
4. `templates/modules/common/message-bar.hypr.live`
   - Added better support for multiple notification messages.
### Stylesheets

The styling of the Volume Pricing templates.
#### New LESS file
1. `stylesheets/modules/product/volume-pricing.less`
   - Styling of Volume Pricing elements
#### Updated LESS file
1. `stylesheets/base/variables.less`
   - Added `highlightColor` used to indicate the applied price band for Volume Pricing.
### Labels

The new Volume Pricing labels are grouped together at the bottom, however, there is one entry for `enterMinProductQuantity` which is adjacent to the existing `enterProductQuantity` label.
1. `labels/en-US.json`
2. `labels/de-DE.json`
### Theme Settings
1. `theme.json`
   - Added setting `listVolumePricing` to enable the API to return volume pricing bands on product listing pages.  For performance reasons, this flag is defaulted to false.  Only enable this setting if you are using volume pricing and want to display it on product listing pages.
2. `theme-ui.json`
   - Exposes the `listVolumePricing` setting in the theme UI in the product listing section.
