### PR TITLE
Removing sort value for the default sort in the drop down.

### DIFF
--- a/templates/modules/common/page-sort.hypr.live
+++ b/templates/modules/common/page-sort.hypr.live
@@ -4,7 +4,7 @@
   <select data-mz-value="sortBy" class="mz-pagingcontrols-pagesort-dropdown" autocomplete="off">
       {% block sort-types %}
       {% for sort in model.sorts %}
-      {% with sort.value|default(themeSettings.defaultSort) as sortValue %}
+      {% with sort.value as sortValue %}
       <option data-mz-url="{% make_url "sorting" model with sortBy=sortValue %}" value="{{ sortValue }}"{% if model.currentSort == sortValue %} selected="selected"{% endif %}>{{ sort.text }}</option>
       {% endwith %}
       {% endfor %}


### PR DESCRIPTION
This update changes the behavior of the page sorting dropdown (templates/modules/common/page-sort.hypr.live ) to remove the sortby parameter for sorts that don't have their own value.  Currently, this only happens for the default entry in the drop down.  With the addition of the sort definition feature (NGCat-744) SiteBuilder will supply the default sort value saved in theme settings to the product search api call instead of supplying this on the URL as a sortBy parameter when the default sort is selected.