### PR TITLE
Google recaptcha support for login pages and popover

### DIFF
--- a/scripts/modules/login-links.js
+++ b/scripts/modules/login-links.js
@@ -1,3 +1,5 @@
+/* globals grecaptcha */
+
 /**
  * Adds a login popover to all login links on a page.
  */
@@ -112,14 +114,14 @@ define(['shim!vendor/bootstrap/js/popover[shim!vendor/bootstrap/js/tooltip[modul
             this.$el = $(el);
             this.loading = false;
             this.setMethodContext();
-            if (!this.pageType){
+            if (!this.pageType) {
                 this.$el.on('click', this.createPopover);
             }
             else {
                this.$el.on('click', _.bind(this.doFormSubmit, this));
             }
         },
-        doFormSubmit: function(e){
+        doFormSubmit: function(e) {
             e.preventDefault();
             this.$parent = this.$el.closest(this.formSelector);
             this[this.pageType]();
@@ -140,16 +142,47 @@ define(['shim!vendor/bootstrap/js/popover[shim!vendor/bootstrap/js/tooltip[modul
             this.$parent[onOrOff]('click', '[data-mz-action="forgotpasswordform"]', this.slideRight);
             this.$parent[onOrOff]('click', '[data-mz-action="loginform"]', this.slideLeft);
             this.$parent[onOrOff]('click', '[data-mz-action="submitlogin"]', this.login);
+            this.$parent[onOrOff]('click', '[data-mz-action="recaptchasubmitlogin"]', this.loginRecaptcha.bind(this));
             this.$parent[onOrOff]('click', '[data-mz-action="submitforgotpassword"]', this.retrievePassword);
             this.$parent[onOrOff]('keypress', 'input', this.handleEnterKey);
         },
         onPopoverShow: function () {
+            var me = this;
             DismissablePopover.prototype.onPopoverShow.apply(this, arguments);
             this.panelWidth = this.$parent.find('.mz-l-slidebox-panel').first().outerWidth();
             this.$slideboxOuter = this.$parent.find('.mz-l-slidebox-outer');
 
             if (this.$el.hasClass('mz-forgot')){
                 this.slideRight();
+            }
+
+            var recaptchaType = HyprLiveContext.locals.themeSettings.recaptchaType;
+
+            var recaptchaContainer = recaptchaType === 'Invisible' ? 'recaptcha-container-global' : 'recaptcha-container-popup';
+
+            if (HyprLiveContext.locals.themeSettings.enableRecaptcha) {
+                if (recaptchaType !== 'Invisible' || !window.renderedRecaptcha) {
+                    grecaptcha.render(
+                        recaptchaContainer,
+                        {
+                            size: recaptchaType === 'Invisible' ? 'invisible' : 'compact',
+                            badge: HyprLiveContext.locals.themeSettings.recaptchaBadgePosition,
+                            theme: HyprLiveContext.locals.themeSettings.recaptchaTheme,
+                            sitekey: HyprLiveContext.locals.themeSettings.recaptchaSiteKey,
+                            callback: function(result) {
+                                window.captchaToken = result;
+
+                                if (recaptchaType === 'Invisible') {
+                                    me.login(result);
+                                }
+                            }
+                        }
+                    );
+                }
+            }
+
+            if (recaptchaType === 'Invisible') {
+                window.renderedRecaptcha = true;
             }
         },
         handleEnterKey: function (e) {
@@ -174,8 +207,38 @@ define(['shim!vendor/bootstrap/js/popover[shim!vendor/bootstrap/js/tooltip[modul
             if (e) e.preventDefault();
             this.$slideboxOuter.css('left', 0);
         },
-        login: function () {
+        loginRecaptcha: function() {
+            var me = this;
 
+            if (HyprLiveContext.locals.themeSettings.recaptchaType !== 'Invisible') {
+                return me.login();
+            }
+
+            if (window.captchaToken) {
+                return me.login(window.captchaToken);
+            }
+
+            if (!window.renderedRecaptcha) {
+                grecaptcha.render(
+                    'recaptcha-container-global',
+                    {
+                        size: HyprLiveContext.locals.themeSettings.recaptchaType === 'Invisible' ? 'invisible' : HyprLiveContext.locals.themeSettings.recaptchaSize,
+                        badge: HyprLiveContext.locals.themeSettings.recaptchaBadgePosition,
+                        theme: HyprLiveContext.locals.themeSettings.recaptchaTheme,
+                        sitekey: HyprLiveContext.locals.themeSettings.recaptchaSiteKey,
+                        callback: function(result) {
+                            window.captchaToken = result;
+                            me.login(result);
+                        }
+                    }
+                );
+
+                window.renderedRecaptcha = true;
+            }
+
+            grecaptcha.execute();
+        },
+        login: function (token) {
             this.setLoading(true);
 
             //NGCOM-623
@@ -193,11 +256,18 @@ define(['shim!vendor/bootstrap/js/popover[shim!vendor/bootstrap/js/tooltip[modul
               returnUrl = this.$parent.find('input[name=returnUrl]').val();
             }
 
-
-            api.action('customer', 'loginStorefront', {
+            var data = {
                 email: this.$parent.find('[data-mz-login-email]').val(),
                 password: this.$parent.find('[data-mz-login-password]').val()
-            }).then(this.handleLoginComplete.bind(this, returnUrl), this.displayApiMessage);
+            };
+
+            if (token) {
+                data.token = token;
+            } else if (window.captchaToken) {
+                data.token = window.captchaToken;
+            }
+
+            api.action('customer', 'loginStorefront', data).then(this.handleLoginComplete.bind(this, returnUrl), this.displayApiMessage);
 
         },
         anonymousorder: function() {
@@ -402,6 +472,32 @@ define(['shim!vendor/bootstrap/js/popover[shim!vendor/bootstrap/js/tooltip[modul
             }
 
         });
-    });
 
+        $('[data-mz-action="recaptcha-submit"]').each(function() {
+            var loginPage = new SignupPopover();
+            loginPage.formSelector = 'form[name="mz-loginform"]';
+            loginPage.pageType = 'loginRecaptcha';
+            loginPage.init(this);
+
+            var recaptchaContainer = HyprLiveContext.locals.themeSettings.recaptchaType === 'Invisible' ? 'recaptcha-container-global' : 'recaptcha-container';
+
+            if (!window.renderedRecaptcha) {
+                grecaptcha.render(
+                    recaptchaContainer,
+                    {
+                        size: HyprLiveContext.locals.themeSettings.recaptchaType === 'Invisible' ? 'invisible' : HyprLiveContext.locals.themeSettings.recaptchaSize,
+                        badge: HyprLiveContext.locals.themeSettings.recaptchaBadgePosition,
+                        theme: HyprLiveContext.locals.themeSettings.recaptchaTheme,
+                        sitekey: HyprLiveContext.locals.themeSettings.recaptchaSiteKey,
+                        callback: function(result) {
+                            window.captchaToken = result;
+                            loginPage.login(result);
+                        }
+                    }
+                );
+            }
+
+            window.renderedRecaptcha = true;
+        });
+    });
 });

--- a/templates/modules/common/login-popover.hypr.live
+++ b/templates/modules/common/login-popover.hypr.live
@@ -4,9 +4,16 @@
       <section data-mz-role="login-form" class="mz-login-form mz-l-slidebox-panel">
         <input name="email" data-mz-login-email placeholder="{{ labels.logInInput }}" type="text" />
         <input name="password" data-mz-login-password placeholder="{{ labels.password }}" type="password" />
+        {% if themeSettings.enableRecaptcha %}
+        <div class="mz-popover-action">
+          <div id="recaptcha-container-popup"></div>
+          (<a data-mz-action="forgotpasswordform" href="javascript:;">{{ labels.forgotPasswordLink }}</a>) <button class="mz-button" data-mz-action="recaptchasubmitlogin">{{ labels.logIn }}</button>
+        </div>
+        {% else %}
         <div class="mz-popover-action">
           (<a data-mz-action="forgotpasswordform" href="javascript:;">{{ labels.forgotPasswordLink }}</a>) <button class="mz-button" data-mz-action="submitlogin">{{ labels.logIn }}</button>
         </div>
+        {% endif %}
       </section>
       <section data-mz-role="forgotpassword-form" class="mz-forgot-password mz-l-slidebox-panel">
         <label>{{ labels.resetPassword }}</label>

--- a/templates/modules/page-header/utility-nav.hypr
+++ b/templates/modules/page-header/utility-nav.hypr
@@ -4,7 +4,7 @@
             <a href="{{siteContext.siteSubdirectory}}/user/order-status?returnUrl={{siteContext.siteSubdirectory}}/myaccount" data-mz-action="anon-order" class="mz-utilitynav-link">{{ labels.orderStatus }}</a>
         </li>
         {% comment %}
-        The below require_script tag does not render anything in the place it's actually inserted; it instead adds the script to a list of scripts  which are then included at the end of the page by RequireJS.
+        The below require_script tag does not render anything in the place it's actually inserted; it instead adds the script to a list of scripts which are then included at the end of the page by RequireJS.
         Use require_script to load AMD modules that are wrapped in define() or require() function calls.
         {% endcomment %}
         {% require_script "modules/login-links" %}

--- a/templates/page.hypr
+++ b/templates/page.hypr
@@ -67,6 +67,10 @@
         <link rel="next" href="{{PageContext.CrawlerInfo.NextUrl}}">
         {% endif %}
 
+        {% if themeSettings.enableRecaptcha %}
+            <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+        {% endif %}
+
         {% block stylesheets %}
         <link rel="stylesheet" href="{% make_url "stylesheet" "/stylesheets/storefront.less" %}" title="default" />
         {% endblock stylesheets %}
@@ -93,6 +97,10 @@
 
 
         <div id="page-wrapper" class="mz-l-pagewrapper">
+            {% if themeSettings.enableRecaptcha %}
+            <div id="recaptcha-container-global"></div>
+            {% endif %}
+
             {% block utility-bar %}
                 {% include "modules/utility-bar/header" %}
             {% endblock utility-bar %}

--- a/templates/pages/login.hypr
+++ b/templates/pages/login.hypr
@@ -30,7 +30,7 @@
             </div>
             <div class="mz-l-column">
                 <h1 class="mz-pagetitle">{{ labels.logIn2 }}</h1>
-                
+
 		        {% dropzone "login-top" scope="template" %}
                 <form method="post" class="mz-loginform mz-loginform-page" name="mz-loginform">
                    <input type="hidden" name="returnUrl" value="{{ model.returnUrl }}" />
@@ -51,6 +51,14 @@
                                 <input name="password"  type="password" data-mz-login-password/>
                             </div>
                         </div>
+                        {% if themeSettings.enableRecaptcha %}
+                        <div class="mz-l-formfieldgroup-row">
+                            <div class="mz-l-formfieldgroup-cell"></div>
+                            <div class="mz-l-formfieldgroup-cell">
+                                <div id="recaptcha-container"></div>
+                            </div>
+                        </div>
+                        {% endif %}
                         <div class="mz-l-formfieldgroup-row">
                             <div class="mz-l-formfieldgroup-cell"></div>
                             <div class="mz-l-formfieldgroup-cell">
@@ -60,11 +68,14 @@
                                 </div>
                             </div>
                         </div>
-                       
                         <div class="mz-l-formfieldgroup-row">
                             <div class="mz-l-formfieldgroup-cell"></div>
                             <div class="mz-l-formfieldgroup-cell">
+                                {% if themeSettings.enableRecaptcha %}
+                                <button class="mz-button mz-button-large mz-login-button" data-mz-action="recaptcha-submit">{{ labels.logIn }}</button>
+                                {% else %}
                                 <button class="mz-button mz-button-large mz-login-button" data-mz-action="loginpage-submit">{{ labels.logIn }}</button>
+                                {% endif %}
                                 <div class="mz-l-formfieldgroup-cell">
                                     <section data-mz-role="popover-message" class="mz-popover-message"></section>
                                 </div>
@@ -73,7 +84,6 @@
                     </div>
                 </form>
             </div>
-            
         </div>
     </div>
 {% endblock body-content %}

--- a/templates/pages/order-status.hypr
+++ b/templates/pages/order-status.hypr
@@ -31,6 +31,14 @@
                                 <input name="password"  type="password" data-mz-login-password/>
                             </div>
                         </div>
+                        {% if themeSettings.enableRecaptcha %}
+                        <div class="mz-l-formfieldgroup-row">
+                            <div class="mz-l-formfieldgroup-cell"></div>
+                            <div class="mz-l-formfieldgroup-cell">
+                                <div id="recaptcha-container"></div>
+                            </div>
+                        </div>
+                        {% endif %}
                         <div class="mz-l-formfieldgroup-row">
                             <div class="mz-l-formfieldgroup-cell"></div>
                             <div class="mz-l-formfieldgroup-cell">
@@ -46,7 +54,11 @@
                         <div class="mz-l-formfieldgroup-row">
                             <div class="mz-l-formfieldgroup-cell"></div>
                             <div class="mz-l-formfieldgroup-cell">
+                                {% if themeSettings.enableRecaptcha %}
+                                <button class="mz-button mz-button-large mz-login-button" data-mz-action="recaptcha-submit">{{ labels.logIn }}</button>
+                                {% else %}
                                 <button class="mz-button mz-button-large mz-login-button" data-mz-action="loginpage-submit">{{ labels.logIn }}</button>
+                                {% endif %}
                                 <div class="mz-l-formfieldgroup-cell">
                                     <section data-mz-role="popover-message" class="mz-popover-message"></section>
                                 </div>

--- a/theme-ui.json
+++ b/theme-ui.json
@@ -19,6 +19,74 @@
         },
         {
             "xtype": "panel",
+            "title": "Recaptcha",
+            "collapsed": false,
+            "items": [
+                {
+                    "xtype": "mz-input-checkbox",
+                    "name": "enableRecaptcha",
+                    "fieldLabel": "Enable Recaptcha"
+                },
+                {
+                    "xtype": "mz-input-text",
+                    "name": "recaptchaSiteKey",
+                    "fieldLabel": "Recaptcha Site Key"
+                },
+                {
+                    "xtype": "mz-input-text",
+                    "name": "__recaptchaSecrete",
+                    "fieldLabel": "Recaptcha Secret",
+                    "inputType": "password"
+                },
+                {
+                    "xtype": "mz-input-dropdown",
+                    "name": "recaptchaType",
+                    "fieldLabel": "Recaptcha Type",
+                    "allowBlank": false,
+                    "forceSelection": true,
+                    "store": [
+                        "Invisible",
+                        "I'm not a robot"
+                    ]
+                },
+                {
+                    "xtype": "mz-input-dropdown",
+                    "name": "recaptchaSize",
+                    "fieldLabel": "Recaptcha Size",
+                    "allowBlank": false,
+                    "forceSelection": true,
+                    "store": [
+                        "normal",
+                        "compact"
+                    ]
+                },
+                {
+                    "xtype": "mz-input-dropdown",
+                    "name": "recaptchaTheme",
+                    "fieldLabel": "Recaptcha Theme",
+                    "allowBlank": false,
+                    "forceSelection": true,
+                    "store": [
+                        "light",
+                        "dark"
+                    ]
+                },
+                {
+                    "xtype": "mz-input-dropdown",
+                    "name": "recaptchaBadgePosition",
+                    "fieldLabel": "Recaptcha Badge Position",
+                    "allowBlank": false,
+                    "forceSelection": true,
+                    "store": [
+                        "bottomright",
+                        "bottomleft",
+                        "inline"
+                    ]
+                }
+            ]
+        },
+        {
+            "xtype": "panel",
             "title": "Filters",
             "collapsed": false,
             "items": [

--- a/theme.json
+++ b/theme.json
@@ -382,6 +382,13 @@
         }
     ],
     "settings": {
+        "enableRecaptcha": false,
+        "recaptchaSiteKey": null,
+        "__recaptchaSecrete": null,
+        "recaptchaType": "Invisible",
+        "recaptchaTheme": "light",
+        "recaptchaSize": "normal",
+        "recaptchaBadgePosition": "bottomright",
         "allowFilterByLocationInventory": false,
         "backofficeDateTimeFormat": "m/d/Y H:i:s O",
         "extendedPropertiesEnabled": false,


### PR DESCRIPTION
# **Login Recaptcha**

## **Overview**
This feature adds Google recaptcha support to login pages and the login popover modal. This is useful to prevent bad actors from abusing the login page by repeatedly submitting failed login attempts to bog down the server.  
  
**Recaptcha support was added to the following areas:**
- /user/login
- /user/order-status (when not logged in)
- login popover modal

**Usage**
- Enabling the feature and changing the options is done through theme settings
- There is a new section for Recaptcha options under a section called 'Recaptcha' on the Theme Settings page

**Settings**
- Enable Recaptcha: This is used to turn the Recaptcha feature on and off
- Recaptcha Site Key: Input your Recaptcha Site Key from the Google dashboard here
- Recaptcha Secret: Input your Recaptcha Secret from the Google dashboard here
- Recaptcha Type: Choose Invisible to use an invisible captcha that validates real users through mouse movements and other secret Google algorithms. Choose 'I'm not a robot' to use a checkbox widget to validate real users. Note that even if you choose Invisible or I'm not a robot, very suspicious users will still be required to solve an image captcha.
- Recaptcha Size: Controls the size of the checkbox widget. This setting does not apply to Invisible Recaptcha type
- Recaptcha Theme: Controls the color of the checkbox widget. This setting does not apply to Invisible Recaptcha type
- Recaptcha Badge Position: Controls the position of the Google Recaptcha badge that appears on pages protected by Recaptcha.

## **File Changes**
### Updated JavaScript files
- `scripts/modules/login-links.js`
### Updated Hypr files
- `templates/page.hypr`
- `templates/pages/login.hypr`
- `templates/pages/order-status.hypr`
- `templates/modules/common/login-popover.hypr.live`
### Updated Theme Settings files
- `theme-ui.json`
- `theme.json`
