### PR TITLE
Prevent all `*.orig` files from being uploaded.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -156,7 +156,7 @@ module.exports = function (grunt) {
           'templates/**/*',
           '*thumb.png',
           '*thumb.jpg',
-          '!*.orig',
+          '!**/*.orig',
           '!.inherited'
         ],
         tasks: [
@@ -187,7 +187,7 @@ module.exports = function (grunt) {
           '*thumb.png',
           '*thumb.jpg',
           'theme-ui.json',
-          '!*.orig',
+          '!**/*.orig',
           '!.inherited'
         ]
       },


### PR DESCRIPTION
The current configuration prevents files created by git merge conflicts (ending in `*.orig`) from being uploaded to Kibo, but only if they are in the root directory of the theme. This change excludes all `*.orig` files anywhere.

This is important especially for template files, because Hypr will load a `*.hypr.orig` file over a `*.hypr` file, displaying the conflict markers on the site.