### PR TITLE
COM-2621 For 'Each' column in shipment details grid used overridePrice and if not then fallback to unitPrice.

### DIFF
--- a/templates/modules/common/email-shipment-summary.hypr.live
+++ b/templates/modules/common/email-shipment-summary.hypr.live
@@ -14,7 +14,7 @@
                       {{ item.name }}
                     </td>
                     <td>{{ item.quantity }}</td>
-                    <td align="right">{{ item.unitPrice|currency }}</td>
+                    <td align="right">{{ item.overridePrice|default(item.unitPrice)|currency }}</td>
                     <td align="right">{{ item.lineItemCost|currency }}</td>
                 </tr>
             </tbody>


### PR DESCRIPTION
Issue-> If the unit price is modified in admin then it's showing the old unit price in the template.
Resolution -> Used the same login that we have used in order admin, use overridePrice, and if that's null then fallback to unitPrice.