### PR TITLE
COM-3147 Support PayPal during Quote checkout

### DIFF
--- a/scripts/modules/models-checkout.js
+++ b/scripts/modules/models-checkout.js
@@ -345,6 +345,9 @@
                 this.isLoading(true);
                 var order = this.getOrder();
                 if (order) {
+                    // Don't update fulfillment info if order is created from a quote.
+                    if (order.get('originalQuoteId')) return false;
+
                     order.apiModel.update({ fulfillmentInfo: me.toJSON() })
                         .then(function (o) {
                             var billingInfo = me.parent.get('billingInfo');

--- a/scripts/modules/xpress-paypal.js
+++ b/scripts/modules/xpress-paypal.js
@@ -23,7 +23,7 @@ function($, Api, CartModels, hyprlivecontext, _) {
             environment: environment.value,
             click: function(event) {
                 event.preventDefault();
-                var url = "../paypal/token?id=" + id + (!document.URL.split('?')[1] ? "": "&" + document.URL.split('?')[1].replace("id="+id,"").replace("&&", "&"));
+                var url = window.location.protocol + "//" + window.location.host + "/paypal/token?id=" + id + (!document.URL.split('?')[1] ? "": "&" + document.URL.split('?')[1].replace("id="+id,"").replace("&&", "&"));
                 if (isCart)
                   url += "&isCart="+ isCart;
                 window.paypal.checkout.initXO();

--- a/templates/modules/checkout/payment-selector.hypr.live
+++ b/templates/modules/checkout/payment-selector.hypr.live
@@ -94,7 +94,7 @@
         {% endif %}
     </div>
     {% endif %}
-    {% if model.originalQuoteId == "" %}
+
     {% with siteContext.checkoutSettings.externalPaymentWorkflowSettings|findwhere("isEnabled", true) as externalPaymentWorkflowsEnabled %}
         {% if externalPaymentWorkflowsEnabled %}
             <div class="mz-l-formfieldgroup-row">
@@ -130,7 +130,7 @@
             {% endfor %}
         {% endif %}
     {% endwith %}
-    {% endif %}
+
     <div class="mz-l-formfieldgroup-row mz-paymentselector-validation">
         <div class="mz-formfieldgroup-cell">
         </div>

--- a/templates/modules/checkout/step-payment-info.hypr.live
+++ b/templates/modules/checkout/step-payment-info.hypr.live
@@ -76,7 +76,7 @@
         </div>
       {% endif %}
 
-      {% if model.originalQuoteId == "" %}
+
       {% if payment.billingInfo.paymentType|lower == "paypalexpress2" || payment.paymentType|lower == "token"  || payment.paymentType|lower  == "paywithamazon"  %}
       {% if model.nonStoreCreditOrGiftCardTotal > 0%}
       {%if model.isExternalCheckoutFlowComplete%}
@@ -114,9 +114,9 @@
           {%endif%}
 
           {% endif %}
-      {% endif %}
-      
       {% endfor %}
+      
+
 
       <div class="mz-l-stack-section mz-paymentselector-separator mz-checkoutform">
             <p>


### PR DESCRIPTION
* Show external payment methods while checking out a quote-order.
* Modifed Paypal Arc action URL to work for both quote-order checkout and normal checkout.
* Added condition to not make call for updating fulfillment info after making payment for a quote-order using Visa.