### PR TITLE
COM-3683 Localize dates on the View/Edit Quote pages

### DIFF
--- a/scripts/modules/b2b-account/edit-quote.js
+++ b/scripts/modules/b2b-account/edit-quote.js
@@ -906,6 +906,10 @@ define([
             var self = this;
 
             var adminUserIds = [];
+            this.model.set('createDateLocale', this.getDateInLocaleFormat(self.model.apiModel.data.auditInfo.createDate));
+            if (self.model.apiModel.data.expirationDate) {
+                this.model.set('expirationDateLocale', this.getDateInLocaleFormat(self.model.apiModel.data.expirationDate));
+            }
             self.setUserNameOnComment(self.model.get('comments'), adminUserIds);
             self.setUserInfoOnAuditHistory(self.model.get('auditHistory'), adminUserIds);
             if (adminUserIds.length > 0) {
@@ -928,6 +932,7 @@ define([
                     }
                     //Need this for hypr filters. Hypr filter not working on complex/nested objects.
                     comments[c].createDate = comments[c].auditInfo.createDate;
+                    comments[c].createDateLocale = this.getDateInLocaleFormat(comments[c].auditInfo.createDate);
                 }
                 this.model.set('comments', comments);
             }
@@ -950,11 +955,15 @@ define([
                     }
                     //Need this for hypr filters. Hypr filter not working on complex/nested objects.
                     auditHistory[a].createDate = auditHistory[a].auditInfo.createDate;
+                    auditHistory[a].createDateLocale = this.getDateInLocaleFormat(auditHistory[a].auditInfo.createDate);
+                    
                 }
                 this.model.set('auditHistory', auditHistory);
             }
         },
-
+        getDateInLocaleFormat: function (dateToConvert) {
+            return (dateToConvert ? new Date(dateToConvert).toLocaleDateString() : "");
+        },
         getAvailableShippingMethods: function () {
             var self = this;
             var json = JSON.parse(JSON.stringify(

--- a/scripts/modules/b2b-account/view-quote.js
+++ b/scripts/modules/b2b-account/view-quote.js
@@ -320,6 +320,10 @@ define([
         addUserInfoOnModel: function () {
             var self = this;
             var adminUserIds = [];
+            this.model.set('createDateLocale', this.getDateInLocaleFormat(self.model.apiModel.data.auditInfo.createDate));
+            if (self.model.apiModel.data.expirationDate) {
+                this.model.set('expirationDateLocale', this.getDateInLocaleFormat(self.model.apiModel.data.expirationDate));
+            }
             self.setUserNameOnComment(self.model.get('comments'), adminUserIds);
             self.setUserInfoOnAuditHistory(self.model.get('auditHistory'), adminUserIds);
             if (adminUserIds.length > 0) {
@@ -341,6 +345,7 @@ define([
                     }
                     //Need this for hypr filters. Hypr filter not working on complex/nested objects.
                     comments[c].createDate = comments[c].auditInfo.createDate;
+                    comments[c].createDateLocale = this.getDateInLocaleFormat(comments[c].auditInfo.createDate);
                 }
                 this.model.set('comments', comments);
             }
@@ -361,9 +366,13 @@ define([
                     }
                     //Need this for hypr filters. Hypr filter not working on complex/nested objects.
                     auditHistory[a].createDate = auditHistory[a].auditInfo.createDate;
+                    auditHistory[a].createDateLocale = this.getDateInLocaleFormat(auditHistory[a].auditInfo.createDate);
                 }
                 this.model.set('auditHistory', auditHistory);
             }
+        },
+        getDateInLocaleFormat: function (dateToConvert) {
+            return (dateToConvert ? new Date(dateToConvert).toLocaleDateString() : "");
         },
         getContactById: function (contactId) {
             var self = this;

--- a/templates/modules/b2b-account/quotes/edit-quote/quote-comments.hypr.live
+++ b/templates/modules/b2b-account/quotes/edit-quote/quote-comments.hypr.live
@@ -33,7 +33,7 @@
                   {% for comment in model.comments|dictsortreversed("createDate") %}
                   <div class="quote-comment">
                       <b>
-                        Commented By: {{comment.auditInfo.createByName || comment.auditInfo.createBy}} - {{ comment.auditInfo.createDate|date("m/d/Y") }}
+                        Commented By: {{comment.auditInfo.createByName || comment.auditInfo.createBy}} - {{ comment.createDateLocale }}
                       </b>
                       <p>
                         {{comment.text}}

--- a/templates/modules/b2b-account/quotes/edit-quote/quote-details.hypr.live
+++ b/templates/modules/b2b-account/quotes/edit-quote/quote-details.hypr.live
@@ -48,7 +48,7 @@
             </dt>
             <dd>
               {% if model.auditInfo.createDate %}
-                {{ model.auditInfo.createDate|date("m/d/Y") }}
+              {{ model.createDateLocale }}
               {% endif %}
             </dd>
             <dt>
@@ -89,7 +89,7 @@
               {% else %}
 
               {% if model.expirationDate %}
-              {{ model.expirationDate|date("m/d/Y") }}
+              {{ model.expirationDateLocale }}
               {% endif %}
 
               {% if model.isSalesRep==true %}

--- a/templates/modules/b2b-account/quotes/quote-history.hypr.live
+++ b/templates/modules/b2b-account/quotes/quote-history.hypr.live
@@ -20,7 +20,7 @@
                       <p>
                         <b>
                           Updated By: {{history.auditInfo.createByName || history.auditInfo.createBy}} {% if history.auditInfo.createByEmail %}({{history.auditInfo.createByEmail}}) {% endif %} -
-                          {{ history.auditInfo.createDate|date("m/d/Y") }}
+                          {{ history.createDateLocale }}
                         </b>
                       </p>                        
                           <table>

--- a/templates/modules/b2b-account/quotes/view-quote/quote-comments.hypr.live
+++ b/templates/modules/b2b-account/quotes/view-quote/quote-comments.hypr.live
@@ -19,7 +19,7 @@
                   <div class="quote-comment">
                     <b>
                       Commented By: {{comment.auditInfo.createByName || comment.auditInfo.createBy}} - {{
-                      comment.auditInfo.createDate|date("m/d/Y") }}
+                      comment.createDateLocale }}
                     </b>
                     <p>
                       {{comment.text}}

--- a/templates/modules/b2b-account/quotes/view-quote/quote-details.hypr.live
+++ b/templates/modules/b2b-account/quotes/view-quote/quote-details.hypr.live
@@ -35,7 +35,7 @@
             </dt>
             <dd>
               {% if model.auditInfo.createDate %}
-              {{ model.auditInfo.createDate|date("m/d/Y") }}
+              {{ model.createDateLocale }}
               {% endif %}
             </dd>
             <dt>
@@ -49,7 +49,7 @@
             </dt>
             <dd>
               {% if model.expirationDate %}
-              {{ model.expirationDate|date("m/d/Y") }}
+              {{ model.expirationDateLocale }}
               {% endif %}
             </dd>
           </dl>


### PR DESCRIPTION
Localize the display of dates and times on the View and Edit Quote pages. Dates and times should display in the client browser's local timezone.
This does not apply to editing the Expiration Date which is still UTC. That will be handled separately.

This was originally fixed in commit e86b324 for COM-3484. The original fix was reverted in commit 391c09d due to some issues.