### PR TITLE
COM-3754 P&D: Update Checkout to hide Shipping Method section for Delivery Items

### DIFF
--- a/scripts/modules/checkout/steps/models-base-checkout-step.js
+++ b/scripts/modules/checkout/steps/models-base-checkout-step.js
@@ -9,7 +9,7 @@ define([
 function ($, _, Hypr, Backbone, api, HyprLiveContext) {
 
     var CheckoutStep = Backbone.MozuModel.extend({
-        helpers: ['stepStatus', 'requiresFulfillmentInfo', 'requiresDigitalFulfillmentContact', 'isMultiShipMode'],  //
+        helpers: ['stepStatus', 'requiresFulfillmentInfo', 'requiresDigitalFulfillmentContact', 'isMultiShipMode', 'requiresShippingMethod'],  //
         // instead of overriding constructor, we are creating
         // a method that only the CheckoutStepView knows to
         // run, so it can run late enough for the parent
@@ -80,6 +80,9 @@ function ($, _, Hypr, Backbone, api, HyprLiveContext) {
         },
         requiresDigitalFulfillmentContact: function () {
             return this.getOrder().get('requiresDigitalFulfillmentContact');
+        },
+        requiresShippingMethod: function () {
+            return this.getOrder().get('requiresShippingMethod');
         },
         edit: function () {
             this.stepStatus('incomplete');

--- a/scripts/modules/checkout/steps/step1/models-step-shipping-info.js
+++ b/scripts/modules/checkout/steps/step1/models-step-shipping-info.js
@@ -438,7 +438,7 @@ function ($, _, Hypr, Backbone, api, HyprLiveContext, CheckoutStep, ShippingDest
                     }
                 }
 
-                if(self.requiresFulfillmentInfo()){
+                if(self.requiresShippingMethod()){
                     self.isLoading(true);
                     checkout.get('shippingInfo').updateShippingMethods().then(function(methods) {
                         if(methods){
@@ -458,8 +458,12 @@ function ($, _, Hypr, Backbone, api, HyprLiveContext, CheckoutStep, ShippingDest
                         checkout.get('shippingInfo').calculateStepStatus();
                     });
                 } else {
-                   self.stepStatus('complete');
-                   checkout.get('billingInfo').calculateStepStatus();
+                    // if shippingMethod is not required, then set ShippingInfo(shipping method) step to complete.
+                    // e.g. If all items are Delivery items or Delivery and Pickup
+                    // then ShippingStep is required but ShippingInfo(shipping method) step is not required
+                    self.stepStatus('complete');
+                    self.getCheckout().get('shippingInfo').stepStatus('complete');
+                    checkout.get('billingInfo').calculateStepStatus();
                 }
             },
             // Breakup for validation

--- a/scripts/modules/models-checkout.js
+++ b/scripts/modules/models-checkout.js
@@ -12,7 +12,7 @@
     function ($, _, Hypr, Backbone, api, CustomerModels, AddressModels, PaymentMethods, HyprLiveContext) {
 
         var CheckoutStep = Backbone.MozuModel.extend({
-            helpers: ['stepStatus', 'requiresFulfillmentInfo','isAwsCheckout','isNonMozuCheckout', 'requiresDigitalFulfillmentContact','isShippingEditHidden'],  //
+            helpers: ['stepStatus', 'requiresFulfillmentInfo','isAwsCheckout','isNonMozuCheckout', 'requiresDigitalFulfillmentContact','isShippingEditHidden', 'requiresShippingMethod'],  //
             // instead of overriding constructor, we are creating
             // a method that only the CheckoutStepView knows to
             // run, so it can run late enough for the parent
@@ -57,6 +57,9 @@
             },
             requiresFulfillmentInfo: function () {
                 return this.getOrder().get('requiresFulfillmentInfo');
+            },
+            requiresShippingMethod: function () {
+                return this.getOrder().get('requiresShippingMethod');
             },
             isAwsCheckout: function() {
                 var activePayments = this.getOrder().apiModel.getActivePayments();
@@ -222,14 +225,27 @@
                                     me.isLoading(false);
                                     parent.isLoading(false);
                                     me.calculateStepStatus();
-                                    parent.calculateStepStatus();
+                                    // if shippingMethod is not required, then set FulfillmentInfo(shipping method) step to complete.
+                                    // e.g. If all items are Delivery items or Delivery and Pickup
+                                    // then FulfillmentContact step is required but FulfillmentInfo(shipping method) step is not required
+                                    if (!me.requiresShippingMethod()) {
+                                        parent.stepStatus("complete");
+                                        parent.parent.get('billingInfo').calculateStepStatus();
+                                    } else {
+                                        parent.calculateStepStatus();
+                                    }
                                 });
                             });
                         } else {
                             me.isLoading(false);
                             parent.isLoading(false);
                             me.calculateStepStatus();
-                            parent.calculateStepStatus();
+                            if (!me.requiresShippingMethod()) {
+                                parent.stepStatus("complete");
+                                parent.parent.get('billingInfo').calculateStepStatus();
+                            } else {
+                                parent.calculateStepStatus();
+                            }
                         }
                     });
                 };

--- a/templates/pages/checkout.hypr
+++ b/templates/pages/checkout.hypr
@@ -59,7 +59,7 @@
                 {% include "modules/checkout/step-shipping-address" %}
             </div>
 
-            <div class="mz-formstep mz-checkoutform-shippingmethod" id="step-shipping-method" {% if not model.requiresFulfillmentInfo %}style="display:none"{% endif %}>
+            <div class="mz-formstep mz-checkoutform-shippingmethod" id="step-shipping-method" {% if not model.requiresShippingMethod %}style="display:none"{% endif %}>
                 {% include "modules/checkout/step-shipping-method" %}
             </div>
 

--- a/templates/pages/checkoutv2.hypr
+++ b/templates/pages/checkoutv2.hypr
@@ -62,7 +62,7 @@
             {% include "modules/multi-ship-checkout/step-shipping-destinations" %}
         </div>
 
-        <div class="mz-formstep mz-checkoutform-shippingmethod" id="step-shipping-method" {% if not model.requiresFulfillmentInfo %}style="display:none"{% endif %}>
+        <div class="mz-formstep mz-checkoutform-shippingmethod" id="step-shipping-method" {% if not model.requiresShippingMethod %}style="display:none"{% endif %}>
             {% include "modules/multi-ship-checkout/step-shipping-methods" %}
         </div>
 


### PR DESCRIPTION
- We don't require Shipping Method for Delivery Items.
- Hence hide that in checkout if cart contains only delivery items or delivery and pickup items.
- Update for both multiship and non-multiship.