### PR TITLE
COM-3740: Remove ShippingMethodCode validation if shipping not required

### DIFF
--- a/scripts/modules/checkout/models-checkout-page.js
+++ b/scripts/modules/checkout/models-checkout-page.js
@@ -366,7 +366,9 @@ var CheckoutPage = Backbone.MozuModel.extend({
                         self.validation = _.pick(self.constructor.prototype.validation, _.filter(_.keys(self.constructor.prototype.validation), function(k) { return k.indexOf('fulfillment') === -1; }));
                     }
 
-
+                    if (!self.get('requiresShippingMethod')) {
+                        self.validation = _.pick(self.constructor.prototype.validation, _.filter(_.keys(self.constructor.prototype.validation), function(k) { return k.indexOf('shippingMethodCode') === -1; }));    
+                    }
 
                     var billingEmail = billingInfo.get('billingContact.email');
                     if (!billingEmail && user.email) billingInfo.set('billingContact.email', user.email);

--- a/scripts/modules/models-checkout.js
+++ b/scripts/modules/models-checkout.js
@@ -1635,6 +1635,10 @@
                         self.validation = _.pick(self.constructor.prototype.validation, _.filter(_.keys(self.constructor.prototype.validation), function(k) { return k.indexOf('fulfillment') === -1; }));
                     }
 
+                    if (!self.get('requiresShippingMethod')) {
+                        self.validation = _.pick(self.constructor.prototype.validation, _.filter(_.keys(self.constructor.prototype.validation), function(k) { return k.indexOf('shippingMethodCode') === -1; }));    
+                    }
+
                     var billingEmail = billingInfo.get('billingContact.email');
 
                     self.get('billingInfo.billingContact').on('change:email', function(model, newVal) {


### PR DESCRIPTION
- we don't require shipping method for Delivery and Pick Items.
- Hence remove validation for that.
- update for multiship and non-multiship