### PR TITLE
Removed logout link for the sale representative

### DIFF
--- a/templates/modules/page-header/utility-nav.hypr
+++ b/templates/modules/page-header/utility-nav.hypr
@@ -14,7 +14,7 @@
       {% if user.isSalesRep %}
       <li class="mz-utilitynav-item">
         <div id="mz-logged-in-notice">
-          Welcome, <a href="{{siteContext.siteSubdirectory}}/selleraccount" class="mz-utilitynav-link">{{user.firstName|default(user.emailAddress)}}</a>! (<a href="{{siteContext.siteSubdirectory}}/logout?returnurl=/user/login" data-mz-action="logout" class="mz-utilitynav-link">{{ labels.logOut }}</a>)
+          Welcome, <a href="{{siteContext.siteSubdirectory}}/selleraccount" class="mz-utilitynav-link">{{user.firstName|default(user.emailAddress)}}</a>!
         </div>
       </li>
       {%else%}


### PR DESCRIPTION
As we do not need logout functionality for salesResp.
It will automatically get logout when user logout from admin.

Ps: It is creating some confusion because when we click on the logout link it is only navigation to login page without logout the user.