### PR TITLE
COM-4464: Fix refund message in gateway GC created email

### DIFF
--- a/templates/email/gateway-giftcard-created.hypr
+++ b/templates/email/gateway-giftcard-created.hypr
@@ -13,19 +13,15 @@
 	{% endif %}
 	</p>
 
-    <p>	
-		{% if model.ReturnId %}
-			{{labels.gatewayGiftCardRefundIntro|safe }}		
+	<p>	
+		{% if model.IsRefund == true %}
+			{{labels.gatewayGiftCardRefundIntro|safe }}	
 		{% else %}
-			{% if model.IsRefund == true %}
-	    		{{labels.gatewayGiftCardRefundIntro|safe }}	
-			{% else %}
-				{{labels.gatewayGiftCardEmailIntro|string_format(model.Order.Data.Brand, model.Order.Data.SenderName)|safe }}</br></br></br>
-				{% if model.GiftMessage %}
-					<p><b>{{ labels.giftMessage }}{{":"}}</b> <span class="mz-price">{{model.GiftMessage}}</span></p>
-				{% endif %}		
-			{% endif %}			
-		{% endif %}
+			{{labels.gatewayGiftCardEmailIntro|string_format(model.Order.Data.Brand, model.Order.Data.SenderName)|safe }}</br></br></br>
+			{% if model.GiftMessage %}
+				<p><b>{{ labels.giftMessage }}{{":"}}</b> <span class="mz-price">{{model.GiftMessage}}</span></p>
+			{% endif %}		
+		{% endif %}			
 	</p>	
 		
 	<p><b>{{labels.orderNumber}}{{":"}}</b> <span class="mz-price">{{model.Order.OrderNumber}}</span></p>


### PR DESCRIPTION
- use `isRefund` flag to decide between _refund_ or _new purchase_ message in the email