### PR TITLE
SU-1100: Add Did-You-Mean for Search Results

### DIFF
--- a/templates/modules/search/did-you-mean.hypr.live
+++ b/templates/modules/search/did-you-mean.hypr.live
@@ -1,0 +1,12 @@
+﻿<div class="mz-did-you-mean">
+    {% with model.spellcheck.candidateCorrections|first as firstCandidate %}
+        {% if firstCandidate.query %}
+            <h2>
+                <span>{{ labels.searchResultsDidyoumean }}:</span>
+                <a href="{% make_url "search" with query=firstCandidate.query and spellcorrectOverride='skipall' as_parameters %}">
+                    {{ firstCandidate.query }}
+                </a>
+            </h2>
+        {% endif %}
+    {% endwith %}
+</div>

--- a/templates/pages/no-search-results.hypr
+++ b/templates/pages/no-search-results.hypr
@@ -9,6 +9,8 @@
 <div class="mz-l-container">
     <h1 class="mz-pagetitle">{{ labels.noResults }}: <span class="mz-searchresults-query">{{ pageContext.search.query }}</span></h1>
 
+    {% include "modules/search/did-you-mean" %}
+
     <p class="mz-searchresults-noresultstext">{{ labels.noResultsText }}</p>
 
     {% dropzone "no-results" scope="template" %}
@@ -19,3 +21,30 @@
 
 {% block body-below-content %}
 {% endblock body-below-content %}
+
+
+
+
+
+
+
+
+
+<div style="color:red;-webkit-border-radius:10px;border:1px solid #900; margin:10px;padding:10px;font-size:1.5em;background-color:#fcc">
+    <h2 style="color:red">DEBUG</h2>
+    <h5>
+        <div>No Search Results</div>
+        <div>AutoCorrected: {{model.spellcheck.autoCorrected}}</div>
+        <div>Original query: {{model.spellcheck.originalQuery}}</div>
+        <div>Corrected query: {{model.spellcheck.correctedQuery}}</div>
+        {% if model.spellcheck.candidateCorrections.count > 0 %}
+            {% with model.spellcheck.candidateCorrections|first as firstCandidate %}
+                {% if firstCandidate.query %}
+                    <div>{{ labels.searchResultsDidyoumean }} : {{ firstCandidate.query }} </div>
+                {% endif %}
+            {% endwith %}
+    
+        {% endif %}
+    </h5>
+</div>
+

--- a/templates/pages/search-interior.hypr
+++ b/templates/pages/search-interior.hypr
@@ -4,12 +4,12 @@
     <h1 class="mz-pagetitle">{{ labels.searchResults }}: <span class="mz-searchresults-query">{{ pageContext.search.query }}</span></h1>
 {% endif %}
 
-{% with model.spellcheck.spellCorrections|first as firstCorrection %}
-    {% if firstCorrection.collationQuery %}
+{% with model.spellcheck.candidateCorrections|first as firstCorrection %}
+    {% if firstCorrection.query %}
         <h2>
             <span>{{ labels.searchResultsDidyoumean }}:</span>
-            <a href="{% make_url "search" with query=firstCorrection.collationQuery and spellCorrectionOverride='skipall' as_parameters %}">
-                {{ firstCorrection.collationQuery }}
+            <a href="{% make_url "search" with query=firstCorrection.query and spellCorrectionOverride='skipall' as_parameters %}">
+                {{ firstCorrection.query }}
             </a>
         </h2>
     {% endif %}
@@ -30,19 +30,20 @@
 <br/>
 <br/>
 
-<h2 style="color:red">START DEBUG: =========================================</h2>
-<h5>
-    <div>AutoCorrected: {{model.spellcheck.autoCorrected}}</div>
-    <div>Original query: {{model.spellcheck.originalQuery}}</div>
-    <div>Corrected query: {{model.spellcheck.correctedQuery}}</div>
-    <div>First Of Text:    {% firstof model.spellcheck.correctedQuery pageContext.search.query %}</div>
-    {% if model.spellcheck.spellCorrections.count > 0 %}
-        {% with model.spellcheck.spellCorrections|first as firstCorrection %}
-            {% if firstCorrection.collationQuery %}
-                <div>{{ labels.searchResultsDidyoumean }} : {{ firstCorrection.collationQuery }} </div>
-            {% endif %}
-        {% endwith %}
 
-    {% endif %}
-<h2 style="color:red">END DEBUG =========================================</h2>
-</h5>
+<div style="color:red;-webkit-border-radius:10px;border:1px solid #900; margin:10px;padding:10px;font-size:1.5em;background-color:#fcc">
+    <h2 style="color:red">DEBUG</h2>
+    <h5>
+        <div>AutoCorrected: {{model.spellcheck.autoCorrected}}</div>
+        <div>Original query: {{model.spellcheck.originalQuery}}</div>
+        <div>Corrected query: {{model.spellcheck.correctedQuery}}</div>
+        {% if model.spellcheck.candidateCorrections.count > 0 %}
+            {% with model.spellcheck.candidateCorrections|first as firstCorrection %}
+                {% if firstCorrection.query %}
+                    <div>{{ labels.searchResultsDidyoumean }} : {{ firstCorrection.query }} </div>
+                {% endif %}
+            {% endwith %}
+    
+        {% endif %}
+    </h5>
+</div>

--- a/templates/pages/search-interior.hypr
+++ b/templates/pages/search-interior.hypr
@@ -4,32 +4,26 @@
     <h1 class="mz-pagetitle">{{ labels.searchResults }}: <span class="mz-searchresults-query">{{ pageContext.search.query }}</span></h1>
 {% endif %}
 
-{% with model.spellcheck.candidateCorrections|first as firstCorrection %}
-    {% if firstCorrection.query %}
-        <h2>
-            <span>{{ labels.searchResultsDidyoumean }}:</span>
-            <a href="{% make_url "search" with query=firstCorrection.query and spellCorrectionOverride='skipall' as_parameters %}">
-                {{ firstCorrection.query }}
-            </a>
-        </h2>
-    {% endif %}
-{% endwith %}
+{% include "modules/search/did-you-mean" %}
 
 {% if model.spellcheck.autoCorrected %}
     {% partial_cache model.categoryId pageContext.Sorting pageContext.Pagination pageContext.query.sortBy model.spellcheck.correctedQuery %}
-    {% include "modules/product/faceted-products" %}
+        {% include "modules/product/faceted-products" %}
     {% endpartial_cache %}
 {% else %}
     {% partial_cache model.categoryId pageContext.Sorting pageContext.Pagination pageContext.query.sortBy pageContext.search.query %}
-    {% include "modules/product/faceted-products" %}
+        {% include "modules/product/faceted-products" %}
     {% endpartial_cache %}
 {% endif %}
 
 {% dropzone "search-results" scope="template" %}
 
-<br/>
-<br/>
 
+
+
+
+<br/>
+<br/>
 
 <div style="color:red;-webkit-border-radius:10px;border:1px solid #900; margin:10px;padding:10px;font-size:1.5em;background-color:#fcc">
     <h2 style="color:red">DEBUG</h2>
@@ -47,3 +41,4 @@
         {% endif %}
     </h5>
 </div>
+


### PR DESCRIPTION
Add Did-You-Mean link when [candidateCorrections] are returned from Product-Runtime API
(keeping debug information for now)

![image](https://user-images.githubusercontent.com/86309323/135777891-d61df48d-6130-4de2-afb6-979c7277c68f.png)

![image](https://user-images.githubusercontent.com/86309323/135777928-d1d47f7f-4393-4a9b-9d5f-3d2d22c96cf7.png)
