### PR TITLE
COM-2609: Order Cancel Email to include post-submit items

### DIFF
--- a/templates/email/order-cancel.hypr
+++ b/templates/email/order-cancel.hypr
@@ -7,6 +7,8 @@
     <p>{{ labels.orderCancelBlob1|string_format(model.orderNumber, model.externalId)|safe }}</p>
 
     <br>
+    <!--POSE stands for Post Order Submit Edit. EX: An order has been submitted and items are added to the order-->
+    <!--If the cancelled order includes POSE items a different template is used for the email-->
     {% if model.hasPOSEItems %}
         <table cellpadding="1" width="100%">
             <thead>

--- a/templates/email/order-cancel.hypr
+++ b/templates/email/order-cancel.hypr
@@ -5,38 +5,60 @@
     <p>{{ labels.orderWelcome }} {{ model.billingInfo.billingContact.firstName }} {{ model.billingInfo.billingContact.lastNameOrSurname }},</p>
     <br>
     <p>{{ labels.orderCancelBlob1|string_format(model.orderNumber, model.externalId)|safe }}</p>
-    
-    <table cellpadding="1" width="100%">
-        <thead>
-            <tr>
-                <td bgcolor="#666666"><font color="#ffffff">{{ labels.product }}</font></td>
-                <td align="right" bgcolor="#666666"><font color="#ffffff">{{ labels.subtotal }}</font></td>
-            </tr>
-        </thead>
-        {% for item in model.items %}
-            <tbody class="mz-ordersummary-lineitems">
-              <tr class="mz-ordersummary-line mz-ordersummary-line-item {% if item.discountTotal > 0 %}is-discounted{% endif %}">
-                    <td class="mz-ordersummary-item-product">
-                      {{ item.product.name }}
-                      {% if item.product.productUsage == 'Bundle' %}
-                      <dl class="mz-propertylist">
-                        {% for bundledProduct in item.product.bundledProducts %}
-                        <dt>{{ bundledProduct.productCode }}</dt>&nbsp;
-                        <dd>{{ bundledProduct.name }} ({{ bundledProduct.quantity }})</dd>
-                        {% endfor %}
-                      </dl>s
-                      {% endif %}
-                    </td>
-                    <td align="right"> {% include "modules/common/email-item-price" %}</td>
-                </tr>
-            </tbody>
-        {% endfor %}
-    </table>
 
-    
-    
-    
-    
+    <br>
+    {% if model.omsShipments.count > 0 %}
+        <table cellpadding="1" width="100%">
+            <thead>
+                <tr>
+                    <td bgcolor="#666666"><font color="#ffffff">{{ labels.product }}</font></td>
+                    <td bgcolor="#666666"><font color="#ffffff">{{ labels.qty }}</font></td>
+                    <td align="right" bgcolor="#666666"><font color="#ffffff">{{ labels.subtotal }}</font></td>
+                </tr>
+            </thead>
+            {% for shipment in model.omsShipments %}
+                {% for item in shipment.canceledItems %}
+                    <tbody class="mz-ordersummary-lineitems">
+                        <tr class="mz-ordersummary-line mz-ordersummary-line-item {% if item.itemDiscount > 0 %}is-discounted{% endif %}">
+                            <td class="mz-ordersummary-item-product">
+                                {{ item.name }}
+                            </td>
+                            <td>
+                                {{ item.quantity }}
+                            </td>
+                            <td align="right"> {% include "modules/common/email-shipment-item-total" %}</td>
+                        </tr>
+                    </tbody>
+                {% endfor %}
+            {% endfor %}
+    {% else %}
+        <table cellpadding="1" width="100%">
+            <thead>
+                <tr>
+                    <td bgcolor="#666666"><font color="#ffffff">{{ labels.product }}</font></td>
+                    <td align="right" bgcolor="#666666"><font color="#ffffff">{{ labels.subtotal }}</font></td>
+                </tr>
+            </thead>
+            {% for item in model.items %}
+                <tbody class="mz-ordersummary-lineitems">
+                    <tr class="mz-ordersummary-line mz-ordersummary-line-item {% if item.discountTotal > 0 %}is-discounted{% endif %}">
+                        <td class="mz-ordersummary-item-product">
+                        {{ item.product.name }}
+                        {% if item.product.productUsage == 'Bundle' %}
+                        <dl class="mz-propertylist">
+                            {% for bundledProduct in item.product.bundledProducts %}
+                            <dt>{{ bundledProduct.productCode }}</dt>&nbsp;
+                            <dd>{{ bundledProduct.name }} ({{ bundledProduct.quantity }})</dd>
+                            {% endfor %}
+                        </dl>s
+                        {% endif %}
+                        </td>
+                        <td align="right"> {% include "modules/common/email-item-total" %}</td>
+                    </tr>
+                </tbody>
+            {% endfor %}
+        </table>
+    {% endif %}
 
     <br>
     <p>{{ labels.orderCancelBlob2|string_format(siteContext.generalSettings.websiteName)|safe }}</p>

--- a/templates/email/order-cancel.hypr
+++ b/templates/email/order-cancel.hypr
@@ -7,7 +7,7 @@
     <p>{{ labels.orderCancelBlob1|string_format(model.orderNumber, model.externalId)|safe }}</p>
 
     <br>
-    {% if (model.omsShipments.count > 0) %}
+    {% if model.hasPOSEItems %}
         <table cellpadding="1" width="100%">
             <thead>
                 <tr>
@@ -51,7 +51,7 @@
                             <dt>{{ bundledProduct.productCode }}</dt>&nbsp;
                             <dd>{{ bundledProduct.name }} ({{ bundledProduct.quantity }})</dd>
                             {% endfor %}
-                        </dl>s
+                        </dl>
                         {% endif %}
                         </td>
                         <td align="right"> {% include "modules/common/email-item-total" %}</td>

--- a/templates/email/order-cancel.hypr
+++ b/templates/email/order-cancel.hypr
@@ -7,7 +7,7 @@
     <p>{{ labels.orderCancelBlob1|string_format(model.orderNumber, model.externalId)|safe }}</p>
 
     <br>
-    {% if model.omsShipments.count > 0 %}
+    {% if (model.omsShipments.count > 0) %}
         <table cellpadding="1" width="100%">
             <thead>
                 <tr>
@@ -31,6 +31,7 @@
                     </tbody>
                 {% endfor %}
             {% endfor %}
+        </table>
     {% else %}
         <table cellpadding="1" width="100%">
             <thead>

--- a/templates/modules/common/email-shipment-item-total.hypr.live
+++ b/templates/modules/common/email-shipment-item-total.hypr.live
@@ -1,0 +1,3 @@
+{% extends "modules/common/shipment-item-total" %}
+
+{% block crossedout-inline-style %}style="text-decoration: line-through;"{% endblock crossedout-inline-style %}

--- a/templates/modules/common/shipment-item-total.hypr.live
+++ b/templates/modules/common/shipment-item-total.hypr.live
@@ -1,0 +1,14 @@
+{% if item.itemDiscount || item.itemDiscount === 0 %}
+	{% if (item.actualPrice|subtract(item.itemDiscount)) < item.actualPrice %}
+		<span class="mz-item-rowtotal is-crossedout" {% block crossedout-inline-style %}{% endblock crossedout-inline-style %}>	{{ item.actualPrice|currency }}</span>
+		<span class="mz-item-rowtotal {% if item.unitPrice > item.actualPrice %}is-saleprice{% endif %}">{{ item.actualPrice|subtract(item.itemDiscount)|currency }}</span>
+	{% else %}
+		{% if item.unitPrice > item.actualPrice %}
+			<span class="mz-item-rowtotal is-saleprice">{{ item.actualPrice|currency }}</span>
+		{% else %}
+			{{ item.actualPrice|subtract(item.itemDiscount)|currency }}
+		{% endif %}
+	{% endif %}
+{% else %}
+	<span class="mz-item-rowtotal {% if item.unitPrice > item.actualPrice  %}is-saleprice{% endif %}">{{ item.actualPrice|currency }}</span>
+{% endif %}

--- a/templates/modules/common/shipment-item-total.hypr.live
+++ b/templates/modules/common/shipment-item-total.hypr.live
@@ -1,14 +1,14 @@
 {% if item.itemDiscount || item.itemDiscount === 0 %}
 	{% if (item.actualPrice|subtract(item.itemDiscount)) < item.actualPrice %}
-		<span class="mz-item-rowtotal is-crossedout" {% block crossedout-inline-style %}{% endblock crossedout-inline-style %}>	{{ item.actualPrice|currency }}</span>
-		<span class="mz-item-rowtotal {% if item.unitPrice > item.actualPrice %}is-saleprice{% endif %}">{{ item.actualPrice|subtract(item.itemDiscount)|currency }}</span>
+		<span class="mz-item-rowtotal is-crossedout" {% block crossedout-inline-style %}{% endblock crossedout-inline-style %}>	{{ item.lineItemCost|currency }}</span>
+		<span class="mz-item-rowtotal {% if item.unitPrice > item.actualPrice %}is-saleprice{% endif %}">{{ item.lineItemCost|subtract(item.itemDiscount)|currency }}</span>
 	{% else %}
 		{% if item.unitPrice > item.actualPrice %}
-			<span class="mz-item-rowtotal is-saleprice">{{ item.actualPrice|currency }}</span>
+			<span class="mz-item-rowtotal is-saleprice ">{{ item.lineItemCost|currency }}</span>
 		{% else %}
-			{{ item.actualPrice|subtract(item.itemDiscount)|currency }}
+			{{ item.lineItemCost|subtract(item.itemDiscount)|currency }}
 		{% endif %}
 	{% endif %}
 {% else %}
-	<span class="mz-item-rowtotal {% if item.unitPrice > item.actualPrice  %}is-saleprice{% endif %}">{{ item.actualPrice|currency }}</span>
+	<span class="mz-item-rowtotal {% if item.unitPrice > item.actualPrice  %}is-saleprice{% endif %}">{{ item.lineItemCost|currency }}</span>
 {% endif %}

--- a/theme.json
+++ b/theme.json
@@ -94,7 +94,13 @@
       "id": "order.cancelled",
       "properties": {},
       "template": "email/order-cancel",
-      "title": "Order Cancel"
+      "title": "Order Canceled"
+    },
+    {
+      "id": "order.cancelledPOSE",
+      "properties": {},
+      "template": "email/order-cancel",
+      "title": "Order Canceled POSE"
     },
     {
       "id": "shipment.itemscanceled",
@@ -176,7 +182,7 @@
       "template": "email/product-return-changed",
       "title": "Return Has Been Updated"
     },
-	{
+    {
       "id": "shipment.transfercreated",
       "properties": {},
       "template": "email/transfer-shipment-created",

--- a/theme.json
+++ b/theme.json
@@ -97,7 +97,7 @@
       "title": "Order Canceled"
     },
     {
-      "id": "order.cancelledPOSE",
+      "id": "order.cancelled.POSE",
       "properties": {},
       "template": "email/order-cancel",
       "title": "Order Canceled POSE"


### PR DESCRIPTION
**JIRA: https://kibo.atlassian.net/browse/COM-2609?atlOrigin=eyJpIjoiYmNhMmVmNjk4ODY0NDRiYWFiM2YyNjM4OTBhZDM0NmMiLCJwIjoiaiJ9**

**Completed Changes: **
- Made adjustment to template to include product quantity.
- The order model now has a list of shipments including POSE (post-submit) shipments, and these are iterated through to get all cancelled items. If this list is empty, then the method used previously to display order items in the email is used.
- Added two hypr files that allow for price strikethrough and discount display for items coming from a shipment model, similar to the existing price strikethrough and discount display for items coming from an order model