### PR TITLE
COM-2651: Order canceled Email showing wrong Subtotal

### DIFF
--- a/templates/email/item-cancel.hypr
+++ b/templates/email/item-cancel.hypr
@@ -96,7 +96,7 @@
                             <td>
                             {{ item.quantity }}
                             </td>
-                            <td align="right"> {{ item.unitPrice|currency }}</td>
+                            <td align="right"> {{ item.lineItemCost|currency }}</td>
                         </tr>
                     </tbody>
                 {% endfor %}

--- a/templates/email/order-cancel.hypr
+++ b/templates/email/order-cancel.hypr
@@ -27,7 +27,7 @@
                       </dl>s
                       {% endif %}
                     </td>
-                    <td align="right"> {% include "modules/common/email-item-price" %}</td>
+                    <td align="right"> {% include "modules/common/email-item-total" %}</td>
                 </tr>
             </tbody>
         {% endfor %}


### PR DESCRIPTION
Item email mail template was using the Unit price in the Subtotal field, changed it to lineItemCost
Order email template was using the email-item-price, changed it to email-item-total