### PR TITLE
SU-946 , SU-945 ; Spell correction with autocorrect and did-you-mean

### DIFF
--- a/labels/de-DE.json
+++ b/labels/de-DE.json
@@ -606,6 +606,8 @@
   "searchByAddress": "Suche nach Adresse",
   "searchExpirationDate": "Ablaufdatum der Suche",
   "searchResults": "Suchergebnisse",
+  "searchResultsAutocorrected": "Es werden Ergebnisse gezeigt für",
+  "searchResultsDidyoumean": "Meinten Sie",
   "searchResultsSummary": "Ihre Suche nach \"{0}\" im {1} ergab {2} Ergebnisse. <a href=\"#\" data-mz-action=\"expandSearch\">Wiederholen Sie diese Suche in allen Kategorien.</a>",
   "searchTitle": "Suchergebnisse für {0}",
   "securityCode": "Sicherheitscode",

--- a/labels/en-US.json
+++ b/labels/en-US.json
@@ -719,6 +719,8 @@
   "searchByAddress": "Search by Address",
   "searchExpirationDate": "Search Expiration Date",
   "searchResults": "Search Results",
+  "searchResultsAutocorrected": "Showing results for",
+  "searchResultsDidyoumean": "Did you mean",
   "searchResultsSummary": "Your search for \"{0}\" within {1} returned {2} results. <a href=\"#\" data-mz-action=\"expandSearch\">Repeat this search across all categories.</a>",
   "searchTitle": "Search Results for {0}",
   "securityCode": "Security Code (CVV2)",

--- a/templates/modules/search/did-you-mean.hypr.live
+++ b/templates/modules/search/did-you-mean.hypr.live
@@ -1,0 +1,12 @@
+﻿<div class="mz-did-you-mean">
+    {% with model.spellcheck.candidateCorrections|first as firstCandidate %}
+        {% if firstCandidate.query %}
+            <h2>
+                <span>{{ labels.searchResultsDidyoumean }}:</span>
+                <a href="{% make_url "search" with query=firstCandidate.query and spellcorrectOverride='skipall' as_parameters %}">
+                    {{ firstCandidate.query }}
+                </a>
+            </h2>
+        {% endif %}
+    {% endwith %}
+</div>

--- a/templates/pages/no-search-results.hypr
+++ b/templates/pages/no-search-results.hypr
@@ -21,30 +21,3 @@
 
 {% block body-below-content %}
 {% endblock body-below-content %}
-
-
-
-
-
-
-
-
-
-<div style="color:red;-webkit-border-radius:10px;border:1px solid #900; margin:10px;padding:10px;font-size:1.5em;background-color:#fcc">
-    <h2 style="color:red">DEBUG</h2>
-    <h5>
-        <div>No Search Results</div>
-        <div>AutoCorrected: {{model.spellcheck.autoCorrected}}</div>
-        <div>Original query: {{model.spellcheck.originalQuery}}</div>
-        <div>Corrected query: {{model.spellcheck.correctedQuery}}</div>
-        {% if model.spellcheck.candidateCorrections.count > 0 %}
-            {% with model.spellcheck.candidateCorrections|first as firstCandidate %}
-                {% if firstCandidate.query %}
-                    <div>{{ labels.searchResultsDidyoumean }} : {{ firstCandidate.query }} </div>
-                {% endif %}
-            {% endwith %}
-    
-        {% endif %}
-    </h5>
-</div>
-

--- a/templates/pages/no-search-results.hypr
+++ b/templates/pages/no-search-results.hypr
@@ -9,6 +9,8 @@
 <div class="mz-l-container">
     <h1 class="mz-pagetitle">{{ labels.noResults }}: <span class="mz-searchresults-query">{{ pageContext.search.query }}</span></h1>
 
+    {% include "modules/search/did-you-mean" %}
+
     <p class="mz-searchresults-noresultstext">{{ labels.noResultsText }}</p>
 
     {% dropzone "no-results" scope="template" %}
@@ -19,3 +21,30 @@
 
 {% block body-below-content %}
 {% endblock body-below-content %}
+
+
+
+
+
+
+
+
+
+<div style="color:red;-webkit-border-radius:10px;border:1px solid #900; margin:10px;padding:10px;font-size:1.5em;background-color:#fcc">
+    <h2 style="color:red">DEBUG</h2>
+    <h5>
+        <div>No Search Results</div>
+        <div>AutoCorrected: {{model.spellcheck.autoCorrected}}</div>
+        <div>Original query: {{model.spellcheck.originalQuery}}</div>
+        <div>Corrected query: {{model.spellcheck.correctedQuery}}</div>
+        {% if model.spellcheck.candidateCorrections.count > 0 %}
+            {% with model.spellcheck.candidateCorrections|first as firstCandidate %}
+                {% if firstCandidate.query %}
+                    <div>{{ labels.searchResultsDidyoumean }} : {{ firstCandidate.query }} </div>
+                {% endif %}
+            {% endwith %}
+    
+        {% endif %}
+    </h5>
+</div>
+

--- a/templates/pages/search-interior.hypr
+++ b/templates/pages/search-interior.hypr
@@ -4,12 +4,16 @@
     <h1 class="mz-pagetitle">{{ labels.searchResults }}: <span class="mz-searchresults-query">{{ pageContext.search.query }}</span></h1>
 {% endif %}
 
-{% if model.spellcheck.didyoumean %}
-    <h2>
-        <span>{{ labels.searchResultsDidyoumean }}:</span>
-        <a href="{% make_url "search" with query=model.spellcheck.didyoumean and spellCorrectionOverride='skipDidyoumean' as_parameters %}">{{ model.spellcheck.didyoumean }}</a>
-    </h2>
-{% endif %}
+{% with model.spellcheck.spellCorrections|first as firstCorrection %}
+    {% if firstCorrection.collationQuery %}
+        <h2>
+            <span>{{ labels.searchResultsDidyoumean }}:</span>
+            <a href="{% make_url "search" with query=firstCorrection.collationQuery and spellCorrectionOverride='skipall' as_parameters %}">
+                {{ firstCorrection.collationQuery }}
+            </a>
+        </h2>
+    {% endif %}
+{% endwith %}
 
 {% if model.spellcheck.autoCorrected %}
     {% partial_cache model.categoryId pageContext.Sorting pageContext.Pagination pageContext.query.sortBy model.spellcheck.correctedQuery %}
@@ -26,13 +30,19 @@
 <br/>
 <br/>
 
-<h2 style="color:red">Debug: ================================</h2>
+<h2 style="color:red">START DEBUG: =========================================</h2>
 <h5>
-      
     <div>AutoCorrected: {{model.spellcheck.autoCorrected}}</div>
     <div>Original query: {{model.spellcheck.originalQuery}}</div>
     <div>Corrected query: {{model.spellcheck.correctedQuery}}</div>
-    
-    <div>Didyoumean: {{model.spellcheck.didyoumean}}</div>
     <div>First Of Text:    {% firstof model.spellcheck.correctedQuery pageContext.search.query %}</div>
+    {% if model.spellcheck.spellCorrections.count > 0 %}
+        {% with model.spellcheck.spellCorrections|first as firstCorrection %}
+            {% if firstCorrection.collationQuery %}
+                <div>{{ labels.searchResultsDidyoumean }} : {{ firstCorrection.collationQuery }} </div>
+            {% endif %}
+        {% endwith %}
+
+    {% endif %}
+<h2 style="color:red">END DEBUG =========================================</h2>
 </h5>

--- a/templates/pages/search-interior.hypr
+++ b/templates/pages/search-interior.hypr
@@ -1,5 +1,38 @@
-﻿<h1 class="mz-pagetitle">{{ labels.searchResults }}: <span class="mz-searchresults-query">{{ pageContext.search.query }}</span></h1>
-{% partial_cache model.categoryId pageContext.Sorting pageContext.Pagination pageContext.query.sortBy pageContext.search.query %}
-{% include "modules/product/faceted-products" %}
-{% endpartial_cache %}
+﻿{% if model.spellcheck.autoCorrected %}
+    <h1 class="mz-pagetitle">{{ labels.searchResultsAutocorrected }}: <span class="mz-searchresults-query">{{ model.spellcheck.correctedQuery }}</span></h1>
+{% else %}
+    <h1 class="mz-pagetitle">{{ labels.searchResults }}: <span class="mz-searchresults-query">{{ pageContext.search.query }}</span></h1>
+{% endif %}
+
+{% if model.spellcheck.didyoumean %}
+    <h2>
+        <span>{{ labels.searchResultsDidyoumean }}:</span>
+        <a href="{% make_url "search" with query=model.spellcheck.didyoumean and spellCorrectionOverride='skipDidyoumean' as_parameters %}">{{ model.spellcheck.didyoumean }}</a>
+    </h2>
+{% endif %}
+
+{% if model.spellcheck.autoCorrected %}
+    {% partial_cache model.categoryId pageContext.Sorting pageContext.Pagination pageContext.query.sortBy model.spellcheck.correctedQuery %}
+    {% include "modules/product/faceted-products" %}
+    {% endpartial_cache %}
+{% else %}
+    {% partial_cache model.categoryId pageContext.Sorting pageContext.Pagination pageContext.query.sortBy pageContext.search.query %}
+    {% include "modules/product/faceted-products" %}
+    {% endpartial_cache %}
+{% endif %}
+
 {% dropzone "search-results" scope="template" %}
+
+<br/>
+<br/>
+
+<h2 style="color:red">Debug: ================================</h2>
+<h5>
+      
+    <div>AutoCorrected: {{model.spellcheck.autoCorrected}}</div>
+    <div>Original query: {{model.spellcheck.originalQuery}}</div>
+    <div>Corrected query: {{model.spellcheck.correctedQuery}}</div>
+    
+    <div>Didyoumean: {{model.spellcheck.didyoumean}}</div>
+    <div>First Of Text:    {% firstof model.spellcheck.correctedQuery pageContext.search.query %}</div>
+</h5>

--- a/templates/pages/search-interior.hypr
+++ b/templates/pages/search-interior.hypr
@@ -17,28 +17,3 @@
 {% endif %}
 
 {% dropzone "search-results" scope="template" %}
-
-
-
-
-
-<br/>
-<br/>
-
-<div style="color:red;-webkit-border-radius:10px;border:1px solid #900; margin:10px;padding:10px;font-size:1.5em;background-color:#fcc">
-    <h2 style="color:red">DEBUG</h2>
-    <h5>
-        <div>AutoCorrected: {{model.spellcheck.autoCorrected}}</div>
-        <div>Original query: {{model.spellcheck.originalQuery}}</div>
-        <div>Corrected query: {{model.spellcheck.correctedQuery}}</div>
-        {% if model.spellcheck.candidateCorrections.count > 0 %}
-            {% with model.spellcheck.candidateCorrections|first as firstCorrection %}
-                {% if firstCorrection.query %}
-                    <div>{{ labels.searchResultsDidyoumean }} : {{ firstCorrection.query }} </div>
-                {% endif %}
-            {% endwith %}
-    
-        {% endif %}
-    </h5>
-</div>
-

--- a/templates/pages/search-interior.hypr
+++ b/templates/pages/search-interior.hypr
@@ -4,45 +4,41 @@
     <h1 class="mz-pagetitle">{{ labels.searchResults }}: <span class="mz-searchresults-query">{{ pageContext.search.query }}</span></h1>
 {% endif %}
 
-{% with model.spellcheck.spellCorrections|first as firstCorrection %}
-    {% if firstCorrection.collationQuery %}
-        <h2>
-            <span>{{ labels.searchResultsDidyoumean }}:</span>
-            <a href="{% make_url "search" with query=firstCorrection.collationQuery and spellCorrectionOverride='skipall' as_parameters %}">
-                {{ firstCorrection.collationQuery }}
-            </a>
-        </h2>
-    {% endif %}
-{% endwith %}
+{% include "modules/search/did-you-mean" %}
 
 {% if model.spellcheck.autoCorrected %}
     {% partial_cache model.categoryId pageContext.Sorting pageContext.Pagination pageContext.query.sortBy model.spellcheck.correctedQuery %}
-    {% include "modules/product/faceted-products" %}
+        {% include "modules/product/faceted-products" %}
     {% endpartial_cache %}
 {% else %}
     {% partial_cache model.categoryId pageContext.Sorting pageContext.Pagination pageContext.query.sortBy pageContext.search.query %}
-    {% include "modules/product/faceted-products" %}
+        {% include "modules/product/faceted-products" %}
     {% endpartial_cache %}
 {% endif %}
 
 {% dropzone "search-results" scope="template" %}
 
+
+
+
+
 <br/>
 <br/>
 
-<h2 style="color:red">START DEBUG: =========================================</h2>
-<h5>
-    <div>AutoCorrected: {{model.spellcheck.autoCorrected}}</div>
-    <div>Original query: {{model.spellcheck.originalQuery}}</div>
-    <div>Corrected query: {{model.spellcheck.correctedQuery}}</div>
-    <div>First Of Text:    {% firstof model.spellcheck.correctedQuery pageContext.search.query %}</div>
-    {% if model.spellcheck.spellCorrections.count > 0 %}
-        {% with model.spellcheck.spellCorrections|first as firstCorrection %}
-            {% if firstCorrection.collationQuery %}
-                <div>{{ labels.searchResultsDidyoumean }} : {{ firstCorrection.collationQuery }} </div>
-            {% endif %}
-        {% endwith %}
+<div style="color:red;-webkit-border-radius:10px;border:1px solid #900; margin:10px;padding:10px;font-size:1.5em;background-color:#fcc">
+    <h2 style="color:red">DEBUG</h2>
+    <h5>
+        <div>AutoCorrected: {{model.spellcheck.autoCorrected}}</div>
+        <div>Original query: {{model.spellcheck.originalQuery}}</div>
+        <div>Corrected query: {{model.spellcheck.correctedQuery}}</div>
+        {% if model.spellcheck.candidateCorrections.count > 0 %}
+            {% with model.spellcheck.candidateCorrections|first as firstCorrection %}
+                {% if firstCorrection.query %}
+                    <div>{{ labels.searchResultsDidyoumean }} : {{ firstCorrection.query }} </div>
+                {% endif %}
+            {% endwith %}
+    
+        {% endif %}
+    </h5>
+</div>
 
-    {% endif %}
-<h2 style="color:red">END DEBUG =========================================</h2>
-</h5>

--- a/templates/pages/search-results.hypr
+++ b/templates/pages/search-results.hypr
@@ -1,16 +1,19 @@
 ﻿{% extends "page" %}
 
-{% block title-tag-content %}{{ labels.searchTitle|string_format(pageContext.search.query) }}  - {% parent %}{% endblock title-tag-content %}
+{% block title-tag-content %}
+    {% if model.spellcheck.autoCorrected %}
+        {{ labels.searchTitle|string_format(model.spellcheck.correctedQuery) }} - {% parent %}
+    {% else %}
+        {{ labels.searchTitle|string_format(pageContext.search.query) }} - {% parent %}
+    {% endif %}
+{% endblock title-tag-content %}
 
 {% block body-tag-classes %} mz-searchresults {% endblock body-tag-classes %}
 
 {% block body-content %}
-
-{% require_script "pages/search" %}
-
-<div {% if pageContext.categoryId %}data-mz-category="{{ pageContext.categoryId }}" {% endif %}data-mz-search="{{ pageContext.search.query }}" class="mz-l-container">
-	{% include "pages/search-interior" %}
-</div>
-
+    {% require_script "pages/search" %}
+    <div {% if pageContext.categoryId %}data-mz-category="{{ pageContext.categoryId }}" {% endif %}
+        data-mz-search="{% firstof model.spellcheck.CorrectedQuery pageContext.search.query %}" class="mz-l-container">
+        {% include "pages/search-interior" %}
+    </div>
 {% endblock body-content %}
-


### PR DESCRIPTION
Added spell correction with autocorrect and did-you-mean.
This feature requires the search schema to have spell-correction on and the search-settings to have autocorrect and/or did-you-mean enabled.

Autocorrect:
* Search results could be autocorrected to a best guess when no results are found

Did-you-mean
* Search-results page suggests a search-query that also has results in the catalog

Example search results page for did-you-mean

![image](https://user-images.githubusercontent.com/86309323/137159104-56dd6969-147c-4c09-83d3-9dce261ea63f.png)
