### PR TITLE
COM-4542: Use lineId property to uniquely identify orderItems instead of Id

### DIFF
--- a/scripts/modules/models-orders.js
+++ b/scripts/modules/models-orders.js
@@ -1,6 +1,7 @@
 define(["modules/api", 'underscore', "modules/backbone-mozu", "hyprlive", "modules/models-product", "modules/models-returns"], function(api, _, Backbone, Hypr, ProductModels, ReturnModels) {
 
     var OrderItem = Backbone.MozuModel.extend({
+            idAttribute: 'lineId',
             relations: {
                 product: ProductModels.Product
             },
@@ -107,6 +108,7 @@ define(["modules/api", 'underscore', "modules/backbone-mozu", "hyprlive", "modul
             model: OrderPackage
         }),
         OrderItemBit = Backbone.MozuModel.extend({
+            idAttribute: 'lineId',
             relations: {
                 product: ProductModels.Product
             },


### PR DESCRIPTION
Issue:
- When we fetch orders in synthesized mode, we group the order items according to their shipments and reset their linedIds.
- So if a shipment with an item having multiple qty was split then the order items would have same id but different lineIds.
- Example:
Order Items: [{id: 1, lineId: 1, qty: 5}]
Split shipment and fetch orders in synthesized mode
Order Items: [{id: 1, lineId: 1, qty: 2}, {id: 1, lineId: 2, qty: 3}]
- In the above case, the orderItem collection in CoreTheme was not able to store the order items into separate models because it was using 'id' property to uniquley identify them.

Fix:
- Use lineId property to uniquely identify orderItems.