### PR TITLE
COM-4893: Use fulfillmentStatus property on order to decide when to show return/replace button

### DIFF
--- a/scripts/modules/models-orders.js
+++ b/scripts/modules/models-orders.js
@@ -316,7 +316,7 @@ define(["modules/api", 'underscore', "modules/backbone-mozu", "hyprlive", "modul
                 rma: ReturnModels.RMA
             },
             handlesMessages: true,
-            helpers: ['getNonShippedItems', 'hasFulfilledPackages', 'hasFulfilledPickups', 'hasFulfilledDigital', 'getInStorePickups', 'getReturnableItems'],
+            helpers: ['getNonShippedItems', 'hasFulfilledPackages', 'hasOrderFulfilled', 'hasFulfilledPickups', 'hasFulfilledDigital', 'getInStorePickups', 'getReturnableItems'],
             _nonShippedItems: {},
             initialize: function() {
                 var self = this;
@@ -339,6 +339,10 @@ define(["modules/api", 'underscore', "modules/backbone-mozu", "hyprlive", "modul
                     }
                 });
                 return hasfulfilledPackage;
+            },
+            hasOrderFulfilled: function() {
+                var self = this;
+                return (self.get('fulfillmentStatus') === "Fulfilled" || self.get('fulfillmentStatus') === "PartiallyFulfilled");
             },
             hasFulfilledPickups: function() {
                 var self = this,

--- a/templates/modules/my-account/order-history-listing-return.hypr.live
+++ b/templates/modules/my-account/order-history-listing-return.hypr.live
@@ -3,7 +3,7 @@
 
 <div class="order-history-listing-return">
 <div class="mz-orderlisting-heading mz-order-history-return-status"><h3>{{labels.orderCreateReturn}}</h3></div>
-    {% if model.hasFulfilledPackages or model.hasFulfilledPickups %}
+    {% if model.hasFulfilledPackages or model.hasFulfilledPickups or model.hasOrderFulfilled %}
         {% block order-packages %}
                 <div class="mz-order-returns">
                     {% for item in model.getReturnableItems %}

--- a/templates/modules/my-account/order-history-listing.hypr.live
+++ b/templates/modules/my-account/order-history-listing.hypr.live
@@ -1,7 +1,7 @@
 {% extends "modules/common/order-listing" %}
 {% block order-items %}
 <div class="order-history-listing">
-    {% if model.isUnified and model.hasFulfilledPackages or model.hasFulfilledPickups %}
+    {% if model.isUnified and model.hasFulfilledPackages or model.hasFulfilledPickups or model.hasOrderFulfilled %}
         <div class="mz-orderlisting-prompt is-warning" data-mz-message-for="noReturnableItems"></div>
             <div class="mz-orderlisting-header">
                 {% if themeSettings.allowCustomerInitiatedReturns and not model.limitPlaceReturns %}


### PR DESCRIPTION
Issue: Fulfillment status for pickups was calculated incorrectly in CRT
Fix: Use rollup status (fulfillmentStatus) instead