### PR TITLE
COM-5064 -Pickup non-shipped items not visible

### DIFF
--- a/scripts/modules/models-orders.js
+++ b/scripts/modules/models-orders.js
@@ -316,7 +316,7 @@ define(["modules/api", 'underscore', "modules/backbone-mozu", "hyprlive", "modul
                 rma: ReturnModels.RMA
             },
             handlesMessages: true,
-            helpers: ['getNonShippedItems', 'hasFulfilledPackages', 'hasOrderFulfilled','hasOrderFullyFulfilled', 'hasFulfilledPickups', 'hasFulfilledDigital', 'getInStorePickups', 'getReturnableItems'],
+            helpers: ['getNonShippedItems', 'hasFulfilledPackages', 'hasOrderFulfilled', 'hasFulfilledPickups', 'hasFulfilledDigital', 'getInStorePickups', 'getReturnableItems'],
             _nonShippedItems: {},
             initialize: function() {
                 var self = this;
@@ -343,10 +343,6 @@ define(["modules/api", 'underscore', "modules/backbone-mozu", "hyprlive", "modul
             hasOrderFulfilled: function() {
                 var self = this;
                 return (self.get('fulfillmentStatus') === "Fulfilled" || self.get('fulfillmentStatus') === "PartiallyFulfilled");
-            },
-            hasOrderFullyFulfilled: function() {
-                var self = this;
-                return (self.get('fulfillmentStatus') === "Fulfilled");
             },
             hasFulfilledPickups: function() {
                 var self = this,

--- a/templates/modules/my-account/order-history-listing.hypr.live
+++ b/templates/modules/my-account/order-history-listing.hypr.live
@@ -39,7 +39,6 @@
         <h2 class="mz-orderlisting-heading">{{labels.orderItemsNotShipped}}</h2>
         <div class="mz-orderlisting-nonShipped">
         {% for item in model.getNonShippedItems %}
-        {%dump item %}
                 {% if item.Type == "BundleItem" %}
                     {% include "modules/my-account/my-account-product-bundle" with model=item %}
                 {% else %}

--- a/templates/modules/my-account/order-history-listing.hypr.live
+++ b/templates/modules/my-account/order-history-listing.hypr.live
@@ -21,7 +21,7 @@
         </div>
     {% endif %}
 
-    {% if model.hasFulfilledPickups %}
+    {% if model.hasFulfilledPickups or model.hasOrderFulfilled %}
         <h2 class="mz-orderlisting-heading">{{labels.orderItemsPickup}}</h2>
         <div class="mz-orderlisting-pickup">
             {% include "modules/my-account/order-history-package-group" with model=model packages=model.pickups %}
@@ -35,7 +35,7 @@
         </div>
     {% endif %}
 
-    {% if not model.hasOrderFullyFulfilled and model.getNonShippedItems.length > 0 %}
+    {% if model.getNonShippedItems.length > 0 %}
         <h2 class="mz-orderlisting-heading">{{labels.orderItemsNotShipped}}</h2>
         <div class="mz-orderlisting-nonShipped">
         {% for item in model.getNonShippedItems %}

--- a/templates/modules/my-account/order-history-listing.hypr.live
+++ b/templates/modules/my-account/order-history-listing.hypr.live
@@ -14,14 +14,14 @@
             </div>
     {% endif %}
 
-    {% if model.hasFulfilledPackages or model.hasOrderFulfilled %}
+    {% if model.hasFulfilledPackages %}
         <h2 class="mz-orderlisting-heading">{{labels.shipped}}</h2>
         <div class="data-mz-order-packages">
             {% include "modules/my-account/order-history-package-group" with model=model packages=model.packages %}
         </div>
     {% endif %}
 
-    {% if model.hasFulfilledPickups or model.hasOrderFulfilled %}
+    {% if model.hasFulfilledPickups %}
         <h2 class="mz-orderlisting-heading">{{labels.orderItemsPickup}}</h2>
         <div class="mz-orderlisting-pickup">
             {% include "modules/my-account/order-history-package-group" with model=model packages=model.pickups %}
@@ -39,12 +39,11 @@
         <h2 class="mz-orderlisting-heading">{{labels.orderItemsNotShipped}}</h2>
         <div class="mz-orderlisting-nonShipped">
         {% for item in model.getNonShippedItems %}
-            {% if item.product.fulfillmentStatus !== "Fulfilled" %}
+        {%dump item %}
                 {% if item.Type == "BundleItem" %}
                     {% include "modules/my-account/my-account-product-bundle" with model=item %}
                 {% else %}
                     {% include "modules/my-account/order-history-listing-item" with model=item %}
-                {% endif %}
             {% endif %}
         {% endfor %}
         </div>


### PR DESCRIPTION
Removed the check on nonShipped items and kept the code as it was earlier and also removed the check of hasOrderFulfilled from pickups and shipped items because now we are getting the proper status of pickups and shipped items from api response.