### PR TITLE
COM-5904: Remove isOriginalCartItem check from multiship checkout

### DIFF
--- a/scripts/modules/checkout/models-checkout-page.js
+++ b/scripts/modules/checkout/models-checkout-page.js
@@ -65,7 +65,7 @@ define([
 
 
 var CheckoutOrder = OrderModels.Order.extend({
-    helpers : ['selectableDestinations', 'isOriginalCartItem', 'getDeliverableItems'],
+    helpers : ['selectableDestinations', 'getDeliverableItems'],
     validation : {
         destinationId : {
             required: true,
@@ -90,11 +90,6 @@ var CheckoutOrder = OrderModels.Order.extend({
             }
         });
         return selectable;
-    },
-    isOriginalCartItem : function(){
-        var self = this;
-        var originalCartItem = self.collection.findWhere({originalCartItemId: self.get('originalCartItemId')});
-        return originalCartItem.id == self.get('id');
     },
     addNewContact: function(){
         var self = this;

--- a/templates/modules/multi-ship-checkout/shipping-destinations-item.hypr.live
+++ b/templates/modules/multi-ship-checkout/shipping-destinations-item.hypr.live
@@ -1,8 +1,6 @@
 {% if model.fulfillmentMethod == "Ship" %}
 <div class="mz-shipping-destination-title mz-l-formfieldgroup-row">
-{% if model.isOriginalCartItem%}
   <h3>{{ model.product.name }}</h3>
-{%endif%}
 </div>
 
 <div class="mz-shipping-row">


### PR DESCRIPTION
**Issue:**
- If I add a checkout item through addCheckoutItem API then originalCartItemId field on checkout item would be undefined.

`self.collection.findWhere({originalCartItemId: self.get('originalCartItemId')});`

- The above code would work in previous version (1.8.3) of underscore.js. It was able to search for checkout item with originalCartItemId as undefined in a collection of checkout items. It would anyway return wrong results if it had multiple items with originalCartItemId as undefined.
After updating underscore verison to 1.13.3 the above code broke. findWhere() returned undefined.

`{% if model.isOriginalCartItem%}`
  `<h3>{{ model.product.name }}</h3>`
`{%endif%}`

- We don't need this code as we'll be always getting product name from refreshandValidate call to product runtime.

**Fix:** Removed the isOriginalCartItem check.