### PR TITLE
COM-6897: Perform rounding as per currency precision

### DIFF
--- a/scripts/modules/checkout/steps/step3/models-payment.js
+++ b/scripts/modules/checkout/steps/step3/models-payment.js
@@ -112,7 +112,7 @@ define([
                   }, 0);
 
                   result = total - giftCardTotal - storeCreditTotal;
-                  return me.roundToPlaces(result, 2);
+                  return me.currencyRound(result);
             },
             resetAddressDefaults: function () {
                 var billingAddress = this.get('billingContact').get('address');
@@ -309,7 +309,7 @@ define([
 
                 //need to round to prevent being over total by .01
                 if (creditAmountToApply > 0) {
-                    creditAmountToApply = self.roundToPlaces(creditAmountToApply, 2);
+                    creditAmountToApply = self.currencyRound(creditAmountToApply);
                 }
 
                 var activeCreditPayments = this.activeStoreCredits();
@@ -388,8 +388,12 @@ define([
                 return deferred.promise;
             },
             areNumbersEqual: function(f1, f2) {
-                var epsilon = 0.01;
-                return (Math.abs(f1 - f2)) < epsilon;
+                var precision = require.mozuData('pagecontext').currencyInfo.precision;
+                if (precision === undefined || precision === null) {
+                    precision = 2;
+                }
+                var epsilon = 1 / Math.pow(10, precision);
+                return (Math.abs(f1 - f2).toFixed(precision)) < epsilon;
             },
             loadGiftCards: function(){
               //TODO: phase 2: get giftCards from customer account
@@ -440,7 +444,7 @@ define([
               }
 
               if (amountToApply > 0) {
-                  amountToApply = self.roundToPlaces(amountToApply, 2);
+                  amountToApply = self.currencyRound(amountToApply);
               }
 
               var activeGiftCards = this.activeGiftCards();
@@ -656,10 +660,15 @@ define([
                     remainingTotal += toBeVoidedPayment;
                 }
                 var maxAmt = remainingTotal < creditModel.get('currentBalance') ? remainingTotal : creditModel.get('currentBalance');
-                return scope.roundToPlaces(maxAmt, 2);
+                return scope.currencyRound(maxAmt);
             },
-            roundToPlaces: function(amt, numberOfDecimalPlaces) {
-                var transmogrifier = Math.pow(10, numberOfDecimalPlaces);
+            
+            currencyRound: function(amt) {
+                var precision = require.mozuData('pagecontext').currencyInfo.precision;
+                if (precision === undefined || precision === null) {
+                    precision = 2;
+                }
+                var transmogrifier = Math.pow(10, precision);
                 return Math.round(amt * transmogrifier) / transmogrifier;
             },
 

--- a/scripts/modules/models-checkout.js
+++ b/scripts/modules/models-checkout.js
@@ -516,7 +516,7 @@
                     }, 0);
 
                     result = total - giftCardTotal - storeCreditTotal;
-                    return me.roundToPlaces(result, 2);
+                    return me.currencyRound(result);
             },
             resetAddressDefaults: function () {
                 var billingAddress = this.get('billingContact').get('address');
@@ -709,7 +709,7 @@
 
                 //need to round to prevent being over total by .01
                 if (creditAmountToApply > 0) {
-                    creditAmountToApply = self.roundToPlaces(creditAmountToApply, 2);
+                    creditAmountToApply = self.currencyRound(creditAmountToApply);
                 }
 
                 var activeCreditPayments = this.activeStoreCredits();
@@ -788,8 +788,12 @@
             },
 
             areNumbersEqual: function(f1, f2) {
-                var epsilon = 0.01;
-                return (Math.abs(f1 - f2)) < epsilon;
+                var precision = require.mozuData('pagecontext').currencyInfo.precision;
+                if (precision === undefined || precision === null) {
+                    precision = 2;
+                }
+                var epsilon = 1 / Math.pow(10, precision);
+                return (Math.abs(f1 - f2).toFixed(precision)) < epsilon;
             },
             loadGiftCards: function(){
               //TODO: phase 2: get giftCards from customer account
@@ -835,7 +839,7 @@
              }
 
              if (amountToApply > 0) {
-                 amountToApply = self.roundToPlaces(amountToApply, 2);
+                 amountToApply = self.currencyRound(amountToApply);
              }
 
              var activeGiftCards = this.activeGiftCards();
@@ -1055,11 +1059,15 @@
                     remainingTotal += toBeVoidedPayment;
                 }
                 var maxAmt = remainingTotal < creditModel.get('currentBalance') ? remainingTotal : creditModel.get('currentBalance');
-                return scope.roundToPlaces(maxAmt, 2);
+                return scope.currencyRound(maxAmt);
             },
 
-            roundToPlaces: function(amt, numberOfDecimalPlaces) {
-                var transmogrifier = Math.pow(10, numberOfDecimalPlaces);
+            currencyRound: function(amt) {
+                var precision = require.mozuData('pagecontext').currencyInfo.precision;
+                if (precision === undefined || precision === null) {
+                    precision = 2;
+                }
+                var transmogrifier = Math.pow(10, precision);
                 return Math.round(amt * transmogrifier) / transmogrifier;
             },
 


### PR DESCRIPTION
- Issue: core-theme was by default rounding store credit amount to 2 decimal places. It caused calculation issues for KWD currency which had precision to 3 decimal places.
- Fix: Perform rounding as per currency precision.