### PR TITLE
FFMT-3648 - new field Product Name in return receipt pdf

### DIFF
--- a/labels/de-DE.json
+++ b/labels/de-DE.json
@@ -778,7 +778,7 @@
   "totalSubstituteEmail":"Gesamt",
   "itemSubstitutedEmail":"Artikel",
   "subtotalSubstituteEmail":"Zwischensumme",
-  "returnReceiptsubstitutedQty":"Ersatzmenge",
-  "returnReceiptsubstitutedProductName":"Produktname",
+  "returnReceiptSubstitutedQty":"Ersatzmenge",
+  "returnReceiptSubstitutedProductName":"Produktname",
   "returnReceiptSubstituteUPCColumn": "UPC ersetzen"
 }

--- a/labels/de-DE.json
+++ b/labels/de-DE.json
@@ -777,5 +777,8 @@
   "eachSubstituteEmail":"Jeder",
   "totalSubstituteEmail":"Gesamt",
   "itemSubstitutedEmail":"Artikel",
-  "subtotalSubstituteEmail":"Artikel"
+  "subtotalSubstituteEmail":"Zwischensumme",
+  "returnReceiptsubstitutedQty":"Ersatzmenge",
+  "returnReceiptsubstitutedProductName":"Produktname",
+  "returnReceiptSubstituteUPCColumn": "UPC ersetzen"
 }

--- a/labels/en-US.json
+++ b/labels/en-US.json
@@ -934,7 +934,7 @@
   "totalSubstituteEmail":"Total",
   "itemSubstitutedEmail":"Item",
   "subtotalSubstituteEmail":"Subtotal",
-  "returnReceiptsubstitutedQty":"Substitute Qty",
-  "returnReceiptsubstitutedProductName":"Product Name",
+  "returnReceiptSubstitutedQty":"Substitute Qty",
+  "returnReceiptSubstitutedProductName":"Product Name",
   "returnReceiptSubstituteUPCColumn": "Substitute UPC"
 }

--- a/labels/en-US.json
+++ b/labels/en-US.json
@@ -933,5 +933,8 @@
   "eachSubstituteEmail":"Each",
   "totalSubstituteEmail":"Total",
   "itemSubstitutedEmail":"Item",
-  "subtotalSubstituteEmail":"Subtotal"
+  "subtotalSubstituteEmail":"Subtotal",
+  "returnReceiptsubstitutedQty":"Substitute Qty",
+  "returnReceiptsubstitutedProductName":"Product Name",
+  "returnReceiptSubstituteUPCColumn": "Substitute UPC"
 }

--- a/templates/back-office/return-receipt-content.hypr
+++ b/templates/back-office/return-receipt-content.hypr
@@ -93,8 +93,8 @@
         <table class="grid substitute-table no-bottommargin">
             <thead>
               <tr>
-                <th class="break-word">{{ labels.returnReceiptsubstitutedProductName }}</th>
-                <th class="break-word">{{ labels.returnReceiptsubstitutedQty }}</th>
+                <th class="break-word">{{ labels.returnReceiptSubstitutedProductName }}</th>
+                <th class="break-word">{{ labels.returnReceiptSubstitutedQty }}</th>
                 <th class="break-word">{{ labels.returnReceiptSubstituteUPCColumn }}</th>
                 <th class="break-word">{{ labels.substituteProductName }}</th>
                 <th class="break-word">{{ labels.returnReceiptItemStatusColumn }}</th>

--- a/templates/back-office/return-receipt-content.hypr
+++ b/templates/back-office/return-receipt-content.hypr
@@ -93,8 +93,9 @@
         <table class="grid substitute-table no-bottommargin">
             <thead>
               <tr>
-                <th class="break-word">{{ labels.quantitySubstituted }}</th>
-                <th class="break-word">{{ labels.returnReceiptItemUPCColumn }}</th>
+                <th class="break-word">{{ labels.returnReceiptsubstitutedProductName }}</th>
+                <th class="break-word">{{ labels.returnReceiptsubstitutedQty }}</th>
+                <th class="break-word">{{ labels.returnReceiptSubstituteUPCColumn }}</th>
                 <th class="break-word">{{ labels.substituteProductName }}</th>
                 <th class="break-word">{{ labels.returnReceiptItemStatusColumn }}</th>
                 <th class="break-word">{{ labels.returnReceiptUnitPriceColumn }}</th>
@@ -108,6 +109,13 @@
                       {% if shipmentItem.lineId == substituteItem.shipmentItemId %}
                         {% if shipmentItem.originalLineId && shipmentItem.length > 0 %}
                         <tr>
+                            <td>
+                              {% for substitutedItems in shipment.substitutedItems %}
+                                {% if shipmentItem.originalLineId == substitutedItems.lineId %}
+                                  <div class="product-name">{{ substitutedItems.name }}</div>
+                                {% endif %}
+                              {% endfor %}
+                            </td>
                             <td>
                                 {{ substituteItem.quantityReceived }}
                             </td>
@@ -134,7 +142,7 @@
                 {% endfor %}
             </tbody>
               <tr>
-                <td class="align-right top-border" colspan="5">
+                <td class="align-right top-border" colspan="6">
                   <b>{{ labels.returnReceiptReductionAmountColumn }}</b>
                 </td>
                 <td class="align-center top-border">{{ model.refundAmount }}</td>


### PR DESCRIPTION
Added new field Product Name in return receipt pdf under substitute section, also changed some verbiage according to the screenshots of this ticket