### PR TITLE
fix: for Guest checkout, logout with saveUserId=true to avoid stale user loop

### DIFF
--- a/templates/pages/login.hypr
+++ b/templates/pages/login.hypr
@@ -22,7 +22,7 @@
                 </div>
                 <div class="mz-l-formfieldgroup-row">
                     <div class="mz-l-formfieldgroup-cell">
-                        <a id="guestCheckout" href="/cart/checkout" class="mz-guest-checkout" data-mz-action="continueAsGuest">
+                        <a id="guestCheckout" href="/logout?saveUserId=true&returnUrl=/cart/checkout" class="mz-guest-checkout" data-mz-action="continueAsGuest">
                             {{ labels.guestCheckoutLink }}
                         </a>
                     </div>


### PR DESCRIPTION
For guest checkout, instead of going to `/cart/checkout`, call `/logout?saveUserId=true&returnUrl=/cart/checkout` in case the user is stale. This will fix any issues getting to checkout for stale users.