### PR TITLE
COM-9520: Add OTP email template

### DIFF
--- a/labels/de-DE.json
+++ b/labels/de-DE.json
@@ -824,14 +824,10 @@
   "orderItemsCanceledBlob": "Die folgenden Artikel der Bestellung {0} haben das Kauflimit überschritten und wurden storniert.",
   "requestCode": "Anfrage Code",
   "backToPasswordLogin": "Zurück zur Anmeldung mit Passwort",
-  "backToLogin": "Zurück zur Anmeldung"
-  "orderItemsCanceledBlob": "Die folgenden Artikel der Bestellung {0} haben das Kauflimit überschritten und wurden storniert.",
+  "backToLogin": "Zurück zur Anmeldung",
   "otpForLoginAdminLabel": "OTP für Login",
   "emailSubjectOtp": "Ihr Einmal-Passwort (OTP) für die Anmeldung",
-  "hi": "Hallo",
   "otpEmailInstruction": "Bitte verwenden Sie das folgende Einmal-Passwort (OTP), um Ihre Anmeldung abzuschließen. Dieses OTP ist für eine begrenzte Zeit gültig.",
   "otpNotRequested": "Wenn Sie dieses OTP nicht angefordert haben, ignorieren Sie diese E-Mail bitte oder wenden Sie sich bei Bedenken an unser Support-Team.",
-  "systemGeneratedEmail": "Dies ist eine systemgenerierte E-Mail. Bitte antworten Sie nicht.",
-  "sincerely": "Mit freundlichen Grüßen",
-  "customerService": "Kundendienst"
+  "systemGeneratedEmail": "Dies ist eine systemgenerierte E-Mail. Bitte antworten Sie nicht."
 }

--- a/labels/de-DE.json
+++ b/labels/de-DE.json
@@ -711,7 +711,6 @@
   "subscriptionCancelledBlob1": "Hallo!<br/><br/> Der Status Ihres Abonnements Nr. {0} wird auf {1} aktualisiert. Wenn Sie Ihr Abonnement anzeigen oder verwalten möchten, besuchen Sie bitte Mein Konto.",
   "subscriptionDetails": "Abonnementdetails",
   "subscriptionErroredBlob1": "Hallo, <br/><br/> Der Status Ihres Abonnements Nr. {0} wird auf {1} aktualisiert. Das Abonnement wurde aufgrund eines möglichen Problems mit der Zahlung oder eines anderen Problems in einen fehlerhaften Zustand verschoben. Bitte wenden Sie sich für weitere Einzelheiten an den Kundendienst. Wenn Sie Ihr Abonnement anzeigen oder verwalten möchten, besuchen Sie bitte <a href=\"https://{2}/myaccount\">Mein Konto</a>.",
-
   "subscriptionFrequency": "Frequenz",
   "subscriptionFrequencyChangedBlob": "Hallo, <br/><br/> Vielen Dank für Ihren Einkauf bei uns unter {0}. Ihr Abonnement wurde aktualisiert. Wenn Sie Ihr Abonnement anzeigen oder verwalten möchten, bitte besuche Mein Konto.",
   "subscriptionFrequencyNotFound": "Keine übereinstimmenden Abonnementhäufigkeiten gefunden",
@@ -826,4 +825,13 @@
   "requestCode": "Anfrage Code",
   "backToPasswordLogin": "Zurück zur Anmeldung mit Passwort",
   "backToLogin": "Zurück zur Anmeldung"
+  "orderItemsCanceledBlob": "Die folgenden Artikel der Bestellung {0} haben das Kauflimit überschritten und wurden storniert.",
+  "otpForLoginAdminLabel": "OTP für Login",
+  "emailSubjectOtp": "Ihr Einmal-Passwort (OTP) für die Anmeldung",
+  "hi": "Hallo",
+  "otpEmailInstruction": "Bitte verwenden Sie das folgende Einmal-Passwort (OTP), um Ihre Anmeldung abzuschließen. Dieses OTP ist für eine begrenzte Zeit gültig.",
+  "otpNotRequested": "Wenn Sie dieses OTP nicht angefordert haben, ignorieren Sie diese E-Mail bitte oder wenden Sie sich bei Bedenken an unser Support-Team.",
+  "systemGeneratedEmail": "Dies ist eine systemgenerierte E-Mail. Bitte antworten Sie nicht.",
+  "sincerely": "Mit freundlichen Grüßen",
+  "customerService": "Kundendienst"
 }

--- a/labels/en-US.json
+++ b/labels/en-US.json
@@ -980,17 +980,13 @@
   "substituteItemNote" : "Item(s) on your order {0} was substituted with another item. If there is anything you don't want, please contact customer care . If you would like to view or manage your order, please visit <a href=\"https://{1}/myaccount\">My Account</a>.",
   "quantityOrdered": "Qty Ordered",
   "quantityCanceled": "Qty Canceled",
+  "otpForLoginAdminLabel": "OTP for Login",
   "orderItemsCanceledBlob": "Following items on the order {0} exceeded the purchase limit and have been canceled.",
   "requestCode": "Request Code",
   "backToPasswordLogin": "Back to Password Login",
-  "backToLogin": "Back to Login"
-  "orderItemsCanceledBlob": "Following items on the order {0} exceeded the purchase limit and have been canceled.",
-  "otpForLoginAdminLabel": "OTP for Login",
+  "backToLogin": "Back to Login",    
   "emailSubjectOtp": "Your One-Time Password (OTP) for Login",
-  "hi": "Hi",
   "otpEmailInstruction": "Please use the following One-Time Password (OTP) to complete your login. This OTP is valid for a limited time.",
   "otpNotRequested": "If you did not request this OTP, please ignore this email or contact our support team if you have concerns.",
-  "systemGeneratedEmail": "This is a system-generated email. Please do not reply.",
-  "sincerely": "Sincerely",
-  "customerService": "Customer Service"
+  "systemGeneratedEmail": "This is a system-generated email. Please do not reply."
 }

--- a/labels/en-US.json
+++ b/labels/en-US.json
@@ -984,4 +984,13 @@
   "requestCode": "Request Code",
   "backToPasswordLogin": "Back to Password Login",
   "backToLogin": "Back to Login"
+  "orderItemsCanceledBlob": "Following items on the order {0} exceeded the purchase limit and have been canceled.",
+  "otpForLoginAdminLabel": "OTP for Login",
+  "emailSubjectOtp": "Your One-Time Password (OTP) for Login",
+  "hi": "Hi",
+  "otpEmailInstruction": "Please use the following One-Time Password (OTP) to complete your login. This OTP is valid for a limited time.",
+  "otpNotRequested": "If you did not request this OTP, please ignore this email or contact our support team if you have concerns.",
+  "systemGeneratedEmail": "This is a system-generated email. Please do not reply.",
+  "sincerely": "Sincerely",
+  "customerService": "Customer Service"
 }

--- a/templates/email/otp-login.hypr
+++ b/templates/email/otp-login.hypr
@@ -1,25 +1,33 @@
 {% extends "email/email" %}
+
 {% block body-content %}
-<div class="emailWrapper">
-    <div class="header-container">
-        <div class="delivery-logo text-left">
-            <!-- You might want to use a generic logo or make it configurable if needed -->
-            <img src="https://kibocommerce.com/wp-content/themes/kibo/images/logo.png" alt="logo">
-        </div>
-        <div class="delivery-title">
-            <p class="storename">{{ siteContext.generalSettings.websiteName }}</p>
-            <p class="title">{{ labels.emailSubjectOtp }}</p> {# Or a more specific title label if you prefer #}
-        </div>
+  <!--- Header --->
+  <div class="mz-otp-email-header">  
+    <img src="https://kibocommerce.com/wp-content/themes/kibo/images/logo.png" alt="logo">
+    <div class="mz-otp-header-body">
+      <p><strong>{{ siteContext.generalSettings.websiteName }}</strong></p>
+      <h3>{{ labels.emailSubjectOtp }}</h3>
     </div>
-    <div class="body-container">
-        <p>{{ labels.hi }}</p><br/>
-        <p>{{ labels.otpEmailInstruction }}</p><br/>
-        <p style="font-size: 18px; font-weight: bold; text-align: center; letter-spacing: 2px; padding: 10px; border: 1px dashed #ccc; background-color: #f9f9f9;">{{ model.Otp }}</p><br/>
-        <p>{{ labels.otpNotRequested }}</p><br/>
-        <p><small>{{ labels.systemGeneratedEmail }}</small></p><br/>
-        <p>{{ labels.sincerely }}<br />
-        {{ labels.customerService }}<br />
-        {{ siteContext.generalSettings.websiteName }}</p>
+  </div>
+  <br/>
+
+  <div class="mz-otp-email-body">
+    {% if user and user.firstName %}
+      {{ labels.emailOpening|string_format(user.firstName)|safe }}
+    {% else %}
+      {{ labels.emailOpeningAlternative|safe }}
+    {% endif %}
+
+    <p>{{ labels.otpEmailInstruction }}</p>
+    
+    <div class="mz-otp-code" style="font-size: 18px; font-weight: bold; text-align: center; letter-spacing: 2px; padding: 15px; border: 1px dashed #ccc; background-color: #f9f9f9; margin: 20px 0;">
+      {{ model.Otp }}
     </div>
-</div>
+
+    <p>{{ labels.otpNotRequested }}</p>
+    
+    <p><small>{{ labels.systemGeneratedEmail }}</small></p>
+
+    {{ labels.emailClosing|string_format(siteContext.generalSettings.websiteName)|safe }}
+  </div>
 {% endblock body-content %}

--- a/templates/email/otp-login.hypr
+++ b/templates/email/otp-login.hypr
@@ -1,0 +1,25 @@
+{% extends "email/email" %}
+{% block body-content %}
+<div class="emailWrapper">
+    <div class="header-container">
+        <div class="delivery-logo text-left">
+            <!-- You might want to use a generic logo or make it configurable if needed -->
+            <img src="https://kibocommerce.com/wp-content/themes/kibo/images/logo.png" alt="logo">
+        </div>
+        <div class="delivery-title">
+            <p class="storename">{{ siteContext.generalSettings.websiteName }}</p>
+            <p class="title">{{ labels.emailSubjectOtp }}</p> {# Or a more specific title label if you prefer #}
+        </div>
+    </div>
+    <div class="body-container">
+        <p>{{ labels.hi }}</p><br/>
+        <p>{{ labels.otpEmailInstruction }}</p><br/>
+        <p style="font-size: 18px; font-weight: bold; text-align: center; letter-spacing: 2px; padding: 10px; border: 1px dashed #ccc; background-color: #f9f9f9;">{{ model.Otp }}</p><br/>
+        <p>{{ labels.otpNotRequested }}</p><br/>
+        <p><small>{{ labels.systemGeneratedEmail }}</small></p><br/>
+        <p>{{ labels.sincerely }}<br />
+        {{ labels.customerService }}<br />
+        {{ siteContext.generalSettings.websiteName }}</p>
+    </div>
+</div>
+{% endblock body-content %}

--- a/templates/email/otp-login.hypr
+++ b/templates/email/otp-login.hypr
@@ -21,7 +21,7 @@
     <p>{{ labels.otpEmailInstruction }}</p>
     
     <div class="mz-otp-code" style="font-size: 18px; font-weight: bold; text-align: center; letter-spacing: 2px; padding: 15px; border: 1px dashed #ccc; background-color: #f9f9f9; margin: 20px 0;">
-      {{ model.Otp }}
+      {{ model.OtpCode }}
     </div>
 
     <p>{{ labels.otpNotRequested }}</p>

--- a/theme.json
+++ b/theme.json
@@ -440,11 +440,10 @@
       "properties": {},
       "template": "email/digitalitem-created",
       "title": "Digital Item Created"
-    },
-    {
-      "id": "otp.login",
+    },    {
+      "id": "user.otpsent",
       "properties": {},
-      "template": "email/email-otp-login",
+      "template": "email/otp-login",
       "title": "OTP for Login"
     }
   ],

--- a/theme.json
+++ b/theme.json
@@ -435,12 +435,17 @@
       "properties": {},
       "template": "email/subscription-paused-reminder",
       "title": "Want to reactivate your paused subscription ?"
-    },
-    {
+    },    {
       "id": "digitalitem.created",
       "properties": {},
       "template": "email/digitalitem-created",
       "title": "Digital Item Created"
+    },
+    {
+      "id": "otp.login",
+      "properties": {},
+      "template": "email/email-otp-login",
+      "title": "OTP for Login"
     }
   ],
   "backOfficeTemplates": [


### PR DESCRIPTION
This pull request introduces changes to support OTP (One-Time Password) functionality for login, including updates to localization files, email templates, and theme configuration. The most important changes are grouped into themes below.

### Localization Updates:

* Added new OTP-related strings to the German localization file (`labels/de-DE.json`) for email subject, instructions, and system-generated email disclaimers.
* Added equivalent OTP-related strings to the English localization file (`labels/en-US.json`) for consistency across supported languages.

### Email Template Addition:

* Created a new email template (`templates/email/otp-login.hypr`) for OTP login emails, including placeholders for dynamic content such as the OTP code, user name, and website name.

### Theme Configuration Update:

* Added a new entry in `theme.json` to define the `user.otpsent` email template for OTP login functionality, ensuring it is properly integrated into the system.