### PR TITLE
CAT-7034 Remove threshold message when no longer present in cart

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Mozu continually updates the Core theme. Sometimes, you may have to merge an upd
 
 For the latest enhancements, see the [Release Notes](https://github.com/Mozu/core-theme/blob/master/RELEASE_NOTES.md).
 
-
+Run npx grunt build-production to create a .zip of the theme for uploading to Admin.

--- a/scripts/modules/models-cart.js
+++ b/scripts/modules/models-cart.js
@@ -101,6 +101,8 @@ define(['underscore', 'modules/backbone-mozu', 'hyprlive', "modules/api", "modul
             this.get("items").on('sync remove', this.fetch, this)
                              .on('loadingchange', this.isLoading, this);
 
+            this.on('sync', this.normalizeDiscountThresholdMessages, this);
+
             this.get("items").each(function(item, el) {
                 if(item.get('fulfillmentLocationCode') && item.get('fulfillmentLocationName')) {
                     self.get('storeLocationsCache').addLocation({
@@ -111,6 +113,25 @@ define(['underscore', 'modules/backbone-mozu', 'hyprlive', "modules/api", "modul
             });
 
             this.get('discountModal').set('discounts', this.getSuggestedDiscounts());
+        },
+        normalizeDiscountThresholdMessages: function(rawPayload) {
+            if (!rawPayload) return;
+
+            var hasThresholdField = Object.prototype.hasOwnProperty.call(rawPayload, 'discountThresholdMessages');
+            var existingMessages = this.get('discountThresholdMessages');
+            var hadMessages = Array.isArray(existingMessages) ? existingMessages.length > 0 : !!existingMessages;
+
+            if (!hadMessages) {
+                if (hasThresholdField && rawPayload.discountThresholdMessages === null) {
+                    this.set('discountThresholdMessages', []);
+                }
+                return;
+            }
+
+            if (!hasThresholdField || rawPayload.discountThresholdMessages === null) {
+                // Reset when the service stops sending threshold data so stale banners do not persist.
+                this.set('discountThresholdMessages', []);
+            }
         },
         getSuggestedDiscounts: function(){
             var self = this;


### PR DESCRIPTION
The threshold message was persisting even after the discount had been applied.  There was no logic to remove it if it is not part of the GetCart response.  This is an old bug surfaced by a fix in catalog that no longer returns an empty threshold message  in the api when none is present.   See CAT-7034.
This pull request introduces a new utility method to help manage discount threshold messages in the cart model, and updates the documentation for building the theme. The main changes are focused on improving cart behavior regarding discount banners and clarifying the build process for developers.

**Cart model improvements:**

* Added a new method `normalizeDiscountThresholdMessages` to the cart model in `scripts/modules/models-cart.js`, which ensures that discount threshold messages are correctly reset or initialized to prevent stale banners from persisting when the backend stops sending threshold data.
* Registered the `normalizeDiscountThresholdMessages` method to run on the cart's `sync` event, so it automatically handles discount threshold messages whenever the cart data is refreshed.

**Documentation update:**

* Updated `README.md` to include instructions for running `npx grunt build-production` to create a `.zip` of the theme for uploading to Admin, making the build process clearer for developers.