### PR TITLE
CAT-7034: Add normalization for discount threshold messages 

### DIFF
--- a/scripts/modules/models-cart.js
+++ b/scripts/modules/models-cart.js
@@ -101,6 +101,8 @@ define(['underscore', 'modules/backbone-mozu', 'hyprlive', "modules/api", "modul
             this.get("items").on('sync remove', this.fetch, this)
                              .on('loadingchange', this.isLoading, this);
 
+            this.on('sync', this.normalizeDiscountThresholdMessages, this);
+
             this.get("items").each(function(item, el) {
                 if(item.get('fulfillmentLocationCode') && item.get('fulfillmentLocationName')) {
                     self.get('storeLocationsCache').addLocation({
@@ -111,6 +113,25 @@ define(['underscore', 'modules/backbone-mozu', 'hyprlive', "modules/api", "modul
             });
 
             this.get('discountModal').set('discounts', this.getSuggestedDiscounts());
+        },
+        normalizeDiscountThresholdMessages: function(rawPayload) {
+            if (!rawPayload) return;
+
+            var hasThresholdField = Object.prototype.hasOwnProperty.call(rawPayload, 'discountThresholdMessages');
+            var existingMessages = this.get('discountThresholdMessages');
+            var hadMessages = Array.isArray(existingMessages) ? existingMessages.length > 0 : !!existingMessages;
+
+            if (!hadMessages) {
+                if (hasThresholdField && rawPayload.discountThresholdMessages === null) {
+                    this.set('discountThresholdMessages', []);
+                }
+                return;
+            }
+
+            if (!hasThresholdField || rawPayload.discountThresholdMessages === null) {
+                // Reset when the service stops sending threshold data so stale banners do not persist.
+                this.set('discountThresholdMessages', []);
+            }
         },
         getSuggestedDiscounts: function(){
             var self = this;

--- a/scripts/modules/models-checkout.js
+++ b/scripts/modules/models-checkout.js
@@ -1716,6 +1716,28 @@
                 _.bindAll(this, 'update', 'onCheckoutSuccess', 'onCheckoutError', 'addNewCustomer', 'saveCustomerCard', 'apiCheckout',
                     'addDigitalCreditToCustomerAccount', 'addCustomerContact', 'addBillingContact', 'addShippingContact', 'addShippingAndBillingContact');
 
+                this.on('sync', this.normalizeDiscountThresholdMessages, this);
+
+            },
+
+            normalizeDiscountThresholdMessages: function(rawPayload) {
+                if (!rawPayload) return;
+
+                var hasThresholdField = Object.prototype.hasOwnProperty.call(rawPayload, 'discountThresholdMessages');
+                var existingMessages = this.get('discountThresholdMessages');
+                var hadMessages = Array.isArray(existingMessages) ? existingMessages.length > 0 : !!existingMessages;
+
+                if (!hadMessages) {
+                    if (hasThresholdField && rawPayload.discountThresholdMessages === null) {
+                        this.set('discountThresholdMessages', []);
+                    }
+                    return;
+                }
+
+                if (!hasThresholdField || rawPayload.discountThresholdMessages === null) {
+                    // Reset when the service stops sending threshold data so stale banners do not persist.
+                    this.set('discountThresholdMessages', []);
+                }
             },
 
             applyAttributes: function() {


### PR DESCRIPTION


This pull request introduces logic to normalize and reset the `discountThresholdMessages` field in both the cart and checkout models. The main goal is to ensure that stale discount threshold banners are cleared when the backend stops sending threshold data, preventing outdated messages from persisting in the UI.

**Discount threshold message normalization:**

* Added a `normalizeDiscountThresholdMessages` method to both the cart (`models-cart.js`) and checkout (`models-checkout.js`) models, which resets the `discountThresholdMessages` array when the backend no longer provides threshold data or explicitly sets it to null. This prevents stale messages from being displayed. [[1]](diffhunk://#diff-690cfa484a619e8e89590ac7433809ee0f4cf9496e9570412e51e4d1d5f8bb4eR117-R135) [[2]](diffhunk://#diff-4ead28e235a7c3744aaa5b1529f8e144e3ee76e52b5b2b2b369587db31370083R1719-R1740)
* Registered the `normalizeDiscountThresholdMessages` method to run on every `sync` event for both models, ensuring normalization occurs after every data fetch. [[1]](diffhunk://#diff-690cfa484a619e8e89590ac7433809ee0f4cf9496e9570412e51e4d1d5f8bb4eR104-R105) [[2]](diffhunk://#diff-4ead28e235a7c3744aaa5b1529f8e144e3ee76e52b5b2b2b369587db31370083R1719-R1740)