### PR TITLE
COM-10345: Include orderId in checkout payload

### DIFF
--- a/scripts/modules/checkout/models-checkout-page.js
+++ b/scripts/modules/checkout/models-checkout-page.js
@@ -961,6 +961,7 @@ define([
                 var orderNumber = this.getOrderNumber(order);
                 var payload = {
                     checkoutSessionId: checkoutSessionId,
+                    orderId: order.id,
                     webCheckoutDetails: {
                         checkoutReviewReturnUrl: window.location.href,
                         checkoutResultReturnUrl: window.location.href

--- a/scripts/modules/models-checkout.js
+++ b/scripts/modules/models-checkout.js
@@ -2185,6 +2185,7 @@
                 var orderNumber = this.getOrderNumber(order);
                 var payload = {
                     checkoutSessionId: checkoutSessionId,
+                    orderId: order.id,
                     webCheckoutDetails: {
                         checkoutReviewReturnUrl: window.location.href,
                         checkoutResultReturnUrl: window.location.href


### PR DESCRIPTION
Add orderId: order.id to the checkout payload in models-checkout-page.js and models-checkout.js so the order identifier is included in requests alongside checkoutSessionId and webCheckoutDetails. This ensures the backend receives the order ID for processing/tracking.